### PR TITLE
Refactor/reliability and tests

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -1,0 +1,62 @@
+name: Build, test, and release
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up NuGet
+        uses: NuGet/setup-nuget@v2
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore dependencies
+        run: nuget restore Hitbtc.sln
+
+      - name: Build release configuration
+        run: dotnet build Hitbtc.sln --configuration Release --no-restore
+
+      - name: Run automated tests
+        run: dotnet test HitBtc.Tests/HitBtc.Tests.csproj --configuration Release --no-build --no-restore --logger "console;verbosity=normal"
+
+      - name: Stage release DLL files
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path artifacts/Hitbtc -Force | Out-Null
+          Copy-Item HitBtc/bin/Release/*.dll artifacts/Hitbtc/
+
+      - name: Upload release DLL artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Hitbtc-release-${{ github.sha }}
+          path: artifacts/Hitbtc/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Create archive for GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        run: Compress-Archive -Path artifacts/Hitbtc/* -DestinationPath "artifacts/Hitbtc-${env:GITHUB_REF_NAME}.zip"
+
+      - name: Create GitHub Release for tag
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$env:GITHUB_REF_NAME" "artifacts/Hitbtc-$env:GITHUB_REF_NAME.zip" --verify-tag --generate-notes --title "Hitbtc $env:GITHUB_REF_NAME"
+
+    permissions:
+      contents: write

--- a/HitBtc.Tests/ApiResponseTests.cs
+++ b/HitBtc.Tests/ApiResponseTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using Hitbtc.HitBtcModel;
+using Xunit;
+
+namespace Hitbtc.Tests
+{
+    public class ApiResponseTests
+    {
+        [Fact]
+        public void SymbolConversion_DeserializesJsonProperties()
+        {
+            var response = new ApiResponse
+            {
+                Content = "{\"id\":\"BTCUSD\",\"baseCurrency\":\"BTC\",\"quoteCurrency\":\"USD\"}"
+            };
+
+            Symbol symbol = response;
+
+            Assert.Equal("BTCUSD", symbol.Id);
+            Assert.Equal("BTC", symbol.BaseCurrency);
+            Assert.Equal("USD", symbol.QuoteCurrency);
+        }
+
+        [Fact]
+        public void BalanceListConversion_DeserializesAllItems()
+        {
+            var response = new ApiResponse
+            {
+                Content = "[{\"currency\":\"BTC\",\"available\":\"1.25\",\"reserved\":\"0.10\"},{\"currency\":\"ETH\",\"available\":\"2\",\"reserved\":\"0\"}]"
+            };
+
+            List<Balance> balances = response;
+
+            Assert.Collection(
+                balances,
+                balance =>
+                {
+                    Assert.Equal("BTC", balance.Currency);
+                    Assert.Equal("1.25", balance.Available);
+                    Assert.Equal("0.10", balance.Reserved);
+                },
+                balance => Assert.Equal("ETH", balance.Currency));
+        }
+
+        [Fact]
+        public void InvalidObjectJson_ReturnsEmptyModelInsteadOfThrowing()
+        {
+            var response = new ApiResponse { Content = "not-json" };
+
+            Symbol symbol = response;
+
+            Assert.NotNull(symbol);
+            Assert.Null(symbol.Id);
+        }
+
+        [Fact]
+        public void InvalidListJson_ReturnsEmptyListInsteadOfThrowing()
+        {
+            var response = new ApiResponse { Content = "not-json" };
+
+            List<Balance> balances = response;
+
+            Assert.NotNull(balances);
+            Assert.Empty(balances);
+        }
+
+        [Fact]
+        public void NullResponse_ConvertsToNullModel()
+        {
+            ApiResponse response = null;
+
+            Symbol symbol = response;
+
+            Assert.Null(symbol);
+        }
+
+        [Fact]
+        public void TickerToString_ContainsImportantMarketFields()
+        {
+            var ticker = new Ticker
+            {
+                Symbol = "BTCUSD",
+                Ask = "101",
+                Bid = "100",
+                Last = "100.5"
+            };
+
+            var text = ticker.ToString();
+
+            Assert.Contains("symbol:BTCUSD", text);
+            Assert.Contains("ask:101", text);
+            Assert.Contains("bid:100", text);
+            Assert.Contains("last:100.5", text);
+        }
+    }
+}

--- a/HitBtc.Tests/ApiResponseTests.cs
+++ b/HitBtc.Tests/ApiResponseTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Hitbtc.HitBtcModel;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Hitbtc.Tests
@@ -43,25 +44,53 @@ namespace Hitbtc.Tests
         }
 
         [Fact]
-        public void InvalidObjectJson_ReturnsEmptyModelInsteadOfThrowing()
+        public void InvalidObjectJson_ThrowsJsonException()
         {
             var response = new ApiResponse { Content = "not-json" };
 
-            Symbol symbol = response;
-
-            Assert.NotNull(symbol);
-            Assert.Null(symbol.Id);
+            Assert.Throws<JsonReaderException>(() =>
+            {
+                Symbol symbol = response;
+            });
         }
 
         [Fact]
-        public void InvalidListJson_ReturnsEmptyListInsteadOfThrowing()
+        public void InvalidListJson_ThrowsJsonException()
         {
             var response = new ApiResponse { Content = "not-json" };
 
-            List<Balance> balances = response;
+            Assert.Throws<JsonReaderException>(() =>
+            {
+                List<Balance> balances = response;
+            });
+        }
 
-            Assert.NotNull(balances);
-            Assert.Empty(balances);
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("null")]
+        public void EmptyObjectResponse_ThrowsJsonSerializationException(string content)
+        {
+            var response = new ApiResponse { Content = content };
+
+            Assert.Throws<JsonSerializationException>(() =>
+            {
+                Symbol symbol = response;
+            });
+        }
+
+        [Fact]
+        public void TickerDictionaryConversion_DeserializesKeysAndNestedValues()
+        {
+            var response = new ApiResponse
+            {
+                Content = "{\"BTCUSD\":{\"last\":\"100.5\"},\"ETHUSD\":{\"last\":\"20.1\"}}"
+            };
+
+            Dictionary<string, Ticker> tickers = response;
+
+            Assert.Equal("100.5", tickers["BTCUSD"].Last);
+            Assert.Equal("20.1", tickers["ETHUSD"].Last);
         }
 
         [Fact]

--- a/HitBtc.Tests/HitBtc.Tests.csproj
+++ b/HitBtc.Tests/HitBtc.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/HitBtc.Tests/HitBtc.Tests.csproj
+++ b/HitBtc.Tests/HitBtc.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="RestSharp" Version="114.0.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HitBtc\Hitbtc.csproj" />
+  </ItemGroup>
+</Project>

--- a/HitBtc.Tests/HitBtcRestApiTests.cs
+++ b/HitBtc.Tests/HitBtcRestApiTests.cs
@@ -38,9 +38,22 @@ namespace Hitbtc.Tests
             var api = new HitBtcRestApi();
             var request = new RestRequest("/api/2/trading/balance", Method.Get);
 
-            var exception = await Assert.ThrowsAsync<Exception>(() => api.Execute(request));
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => api.Execute(request));
 
-            Assert.Equal("AccessTokenInvalid", exception.Message);
+            Assert.Contains("requires authorization", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "secret")]
+        [InlineData("", "secret")]
+        [InlineData("key", null)]
+        [InlineData("key", "  ")]
+        public void Authorize_MissingCredential_ThrowsAndKeepsUnauthorized(string apiKey, string secretKey)
+        {
+            var api = new HitBtcRestApi();
+
+            Assert.Throws<ArgumentException>(() => api.Authorize(apiKey, secretKey));
+            Assert.False(api.IsAuthorized);
         }
 
         private static string ReadPrivateField(HitBtcRestApi api, string fieldName)

--- a/HitBtc.Tests/HitBtcRestApiTests.cs
+++ b/HitBtc.Tests/HitBtcRestApiTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using RestSharp;
+using Xunit;
+
+namespace Hitbtc.Tests
+{
+    public class HitBtcRestApiTests
+    {
+        [Fact]
+        public void Constructor_InitializesAllApiCategories()
+        {
+            var api = new HitBtcRestApi();
+
+            Assert.NotNull(api.PublicData);
+            Assert.NotNull(api.Trading);
+            Assert.NotNull(api.Account);
+            Assert.NotNull(api.TradingHistory);
+            Assert.False(api.IsAuthorized);
+        }
+
+        [Fact]
+        public void Authorize_StoresCredentialsAndMarksClientAsAuthorized()
+        {
+            var api = new HitBtcRestApi();
+
+            api.Authorize("api-key", "secret-key");
+
+            Assert.True(api.IsAuthorized);
+            Assert.Equal("api-key", ReadPrivateField(api, "_apiKey"));
+            Assert.Equal("secret-key", ReadPrivateField(api, "_secretKey"));
+        }
+
+        [Fact]
+        public async Task Execute_AuthenticatedRequestWithoutAuthorization_ThrowsBeforeNetworkCall()
+        {
+            var api = new HitBtcRestApi();
+            var request = new RestRequest("/api/2/trading/balance", Method.Get);
+
+            var exception = await Assert.ThrowsAsync<Exception>(() => api.Execute(request));
+
+            Assert.Equal("AccessTokenInvalid", exception.Message);
+        }
+
+        private static string ReadPrivateField(HitBtcRestApi api, string fieldName)
+        {
+            var field = typeof(HitBtcRestApi).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return (string)field.GetValue(api);
+        }
+    }
+}

--- a/HitBtc.Tests/HitBtcSocketApiTests.cs
+++ b/HitBtc.Tests/HitBtcSocketApiTests.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hitbtc.Tests
+{
+    public class HitBtcSocketApiTests
+    {
+        [Fact]
+        public void Constructor_InitializesSocketCategories()
+        {
+            var api = new HitBtcSocketApi();
+
+            Assert.NotNull(api.MarketData);
+            Assert.NotNull(api.Trading);
+            Assert.False(api.IsAuthorized);
+        }
+
+        [Fact]
+        public void Authorize_MarksSocketClientAsAuthorized()
+        {
+            var api = new HitBtcSocketApi();
+
+            api.Authorize("api-key", "secret-key");
+
+            Assert.True(api.IsAuthorized);
+        }
+
+        [Fact]
+        public async Task Execute_AuthenticatedRequestWithoutAuthorization_ReturnsNullWithoutConnecting()
+        {
+            var api = new HitBtcSocketApi();
+
+            var response = await api.Execute("{}", true);
+
+            Assert.Null(response);
+        }
+    }
+}

--- a/HitBtc.Tests/HitBtcSocketApiTests.cs
+++ b/HitBtc.Tests/HitBtcSocketApiTests.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -8,31 +14,157 @@ namespace Hitbtc.Tests
         [Fact]
         public void Constructor_InitializesSocketCategories()
         {
-            var api = new HitBtcSocketApi();
-
-            Assert.NotNull(api.MarketData);
-            Assert.NotNull(api.Trading);
-            Assert.False(api.IsAuthorized);
+            using (var api = new HitBtcSocketApi())
+            {
+                Assert.NotNull(api.MarketData);
+                Assert.NotNull(api.Trading);
+                Assert.False(api.IsAuthorized);
+            }
         }
 
         [Fact]
-        public void Authorize_MarksSocketClientAsAuthorized()
+        public void Authorize_MissingCredential_ThrowsAndKeepsUnauthorized()
         {
-            var api = new HitBtcSocketApi();
-
-            api.Authorize("api-key", "secret-key");
-
-            Assert.True(api.IsAuthorized);
+            using (var api = new HitBtcSocketApi())
+            {
+                Assert.Throws<ArgumentException>(() => api.Authorize("", "secret"));
+                Assert.Throws<ArgumentException>(() => api.Authorize("key", null));
+                Assert.False(api.IsAuthorized);
+            }
         }
 
         [Fact]
-        public async Task Execute_AuthenticatedRequestWithoutAuthorization_ReturnsNullWithoutConnecting()
+        public async Task Execute_WithoutAuthorization_ThrowsWithoutConnecting()
         {
-            var api = new HitBtcSocketApi();
+            var socket = new FakeWebSocketClient();
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(() => api.Execute("{}", true));
+                Assert.Equal(0, socket.ConnectCount);
+            }
+        }
 
-            var response = await api.Execute("{}", true);
+        [Fact]
+        public async Task Execute_FragmentedUtf8Message_AssemblesExactReceivedBytes()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueTextFragments("{\"result\":\"", "سلام", "\"}");
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                var response = await api.Execute("{}", false);
+                Assert.Equal("{\"result\":\"سلام\"}", response.Content);
+                Assert.DoesNotContain("\0", response.Content);
+            }
+        }
 
-            Assert.Null(response);
+        [Fact]
+        public async Task Execute_RepeatedRequests_ReusesOpenConnection()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueText("{\"id\":1}");
+            socket.EnqueueText("{\"id\":2}");
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                await api.Execute("{\"id\":1}", false);
+                await api.Execute("{\"id\":2}", false);
+                Assert.Equal(1, socket.ConnectCount);
+                Assert.Equal(2, socket.SentMessages.Count);
+            }
+        }
+
+        [Fact]
+        public async Task Execute_AuthenticatedRequests_AuthenticateOnlyOnce()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueText("{\"result\":true}");
+            socket.EnqueueText("{\"result\":[]}");
+            socket.EnqueueText("{\"result\":[]}");
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                api.Authorize("api-key", "secret-key");
+                await api.Execute("{\"method\":\"first\"}");
+                await api.Execute("{\"method\":\"second\"}");
+                Assert.Equal(1, socket.SentMessages.Count(x => x.Contains("\"method\":\"login\"")));
+            }
+        }
+
+        [Fact]
+        public async Task Execute_AuthenticationError_ThrowsMeaningfulException()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueText("{\"error\":{\"message\":\"invalid\"}}");
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                api.Authorize("key", "secret");
+                var error = await Assert.ThrowsAsync<InvalidOperationException>(() => api.Execute("{}"));
+                Assert.Contains("authentication failed", error.Message);
+            }
+        }
+
+        [Fact]
+        public async Task Execute_ServerClose_ThrowsWebSocketException()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueClose();
+            using (var api = new HitBtcSocketApi(socket))
+                await Assert.ThrowsAsync<WebSocketException>(() => api.Execute("{}", false));
+        }
+
+        [Fact]
+        public async Task Execute_CancelledToken_CancelsBeforeNetworkOperation()
+        {
+            var socket = new FakeWebSocketClient();
+            using (var api = new HitBtcSocketApi(socket))
+            using (var source = new CancellationTokenSource())
+            {
+                source.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => api.Execute("{}", false, source.Token));
+                Assert.Equal(0, socket.ConnectCount);
+            }
+        }
+
+        private sealed class FakeWebSocketClient : IWebSocketClient
+        {
+            private readonly Queue<Fragment> _fragments = new Queue<Fragment>();
+            public WebSocketState State { get; private set; } = WebSocketState.None;
+            public int ConnectCount { get; private set; }
+            public List<string> SentMessages { get; } = new List<string>();
+
+            public void EnqueueText(string text) => Enqueue(text, WebSocketMessageType.Text, true);
+            public void EnqueueTextFragments(params string[] parts)
+            {
+                for (var i = 0; i < parts.Length; i++) Enqueue(parts[i], WebSocketMessageType.Text, i == parts.Length - 1);
+            }
+            public void EnqueueClose() => Enqueue("", WebSocketMessageType.Close, true);
+            private void Enqueue(string text, WebSocketMessageType type, bool end) =>
+                _fragments.Enqueue(new Fragment(Encoding.UTF8.GetBytes(text), type, end));
+
+            public Task ConnectAsync(Uri uri, CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested(); ConnectCount++; State = WebSocketState.Open; return Task.CompletedTask;
+            }
+            public Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType type, bool end, CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested();
+                SentMessages.Add(Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count));
+                return Task.CompletedTask;
+            }
+            public Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested();
+                var item = _fragments.Dequeue();
+                Array.Copy(item.Bytes, 0, buffer.Array, buffer.Offset, item.Bytes.Length);
+                return Task.FromResult(new WebSocketReceiveResult(item.Bytes.Length, item.Type, item.End));
+            }
+            public void Dispose() => State = WebSocketState.Closed;
+
+            private sealed class Fragment
+            {
+                public Fragment(byte[] bytes, WebSocketMessageType type, bool end) { Bytes = bytes; Type = type; End = end; }
+                public byte[] Bytes { get; }
+                public WebSocketMessageType Type { get; }
+                public bool End { get; }
+            }
         }
     }
 }

--- a/HitBtc.Tests/RestRequestConstructionTests.cs
+++ b/HitBtc.Tests/RestRequestConstructionTests.cs
@@ -1,0 +1,107 @@
+using System.Linq;
+using System.Threading.Tasks;
+using RestSharp;
+using Xunit;
+
+namespace Hitbtc.Tests
+{
+    public class RestRequestConstructionTests
+    {
+        [Fact]
+        public async Task PostWithdraw_ValidInput_UsesPostAndFormParameters()
+        {
+            var api = new CapturingRestApi("{}");
+
+            await api.Account.PostWithraw("BTC", 2, "wallet-address");
+
+            Assert.Equal(Method.Post, api.Request.Method);
+            Assert.Equal("/api/2/account/crypto/withdraw", api.Request.Resource);
+            AssertParameter(api.Request, "currency", "BTC", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "amount", "2", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "address", "wallet-address", ParameterType.GetOrPost);
+        }
+
+        [Fact]
+        public async Task PutWithdraw_ValidId_UsesPutAndPathParameter()
+        {
+            var api = new CapturingRestApi("{}");
+
+            await api.Account.PutWithraw("withdraw-1");
+
+            Assert.Equal(Method.Put, api.Request.Method);
+            AssertParameter(api.Request, "id", "withdraw-1", ParameterType.UrlSegment);
+        }
+
+        [Fact]
+        public async Task PostOrder_ValidInput_UsesPostAndFormParameters()
+        {
+            var api = new CapturingRestApi("{}");
+
+            await api.Trading.PostOrders("BTCUSD", "1.5", price: "100");
+
+            Assert.Equal(Method.Post, api.Request.Method);
+            AssertParameter(api.Request, "symbol", "BTCUSD", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "quantity", "1.5", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "price", "100", ParameterType.GetOrPost);
+        }
+
+        [Fact]
+        public async Task DeleteOrder_ValidId_UsesIdInResourcePath()
+        {
+            var api = new CapturingRestApi("{}");
+
+            await api.Trading.DeleteOrder("client-1");
+
+            Assert.Equal(Method.Delete, api.Request.Method);
+            Assert.Equal("/api/2/order/{clientOrderId}", api.Request.Resource);
+            AssertParameter(api.Request, "clientOrderId", "client-1", ParameterType.UrlSegment);
+        }
+
+        [Fact]
+        public async Task GetOrders_WithSymbol_UsesQueryParameter()
+        {
+            var api = new CapturingRestApi("[]");
+
+            await api.Trading.GetOrders("BTCUSD");
+
+            Assert.Equal(Method.Get, api.Request.Method);
+            AssertParameter(api.Request, "symbol", "BTCUSD", ParameterType.QueryString);
+        }
+
+        [Fact]
+        public async Task GetCandles_WithPeriod_UsesPeriodQueryParameter()
+        {
+            var api = new CapturingRestApi("[]");
+
+            await api.PublicData.GetCandles("BTCUSD", PublicEnum.EnPeriod.H4);
+
+            AssertParameter(api.Request, "symbol", "BTCUSD", ParameterType.UrlSegment);
+            AssertParameter(api.Request, "period", "H4", ParameterType.QueryString);
+        }
+
+        private static void AssertParameter(RestRequest request, string name, string value, ParameterType type)
+        {
+            var parameter = request.Parameters.Single(item => item.Name == name);
+            Assert.Equal(type, parameter.Type);
+            Assert.Equal(value, parameter.Value.ToString());
+        }
+
+        private sealed class CapturingRestApi : HitBtcRestApi
+        {
+            private readonly string _content;
+
+            public CapturingRestApi(string content)
+            {
+                _content = content;
+            }
+
+            public RestRequest Request { get; private set; }
+
+            public override Task<ApiResponse> Execute(RestRequest request, bool requireAuthentication = true)
+            {
+                Request = request;
+                return Task.FromResult(new ApiResponse { Content = _content });
+            }
+        }
+    }
+}

--- a/HitBtc.Tests/UtilitiesTests.cs
+++ b/HitBtc.Tests/UtilitiesTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace Hitbtc.Tests
+{
+    public class UtilitiesTests
+    {
+        [Theory]
+        [InlineData("Hello", "hello")]
+        [InlineData("A", "a")]
+        [InlineData("alreadyLower", "alreadyLower")]
+        public void FirstCharToLower_ValidInput_LowersOnlyFirstCharacter(string input, string expected)
+        {
+            Assert.Equal(expected, Utilities.FirstCharToLower(input));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void FirstCharToLower_EmptyInput_ThrowsArgumentException(string input)
+        {
+            Assert.Throws<ArgumentException>(() => Utilities.FirstCharToLower(input));
+        }
+
+        [Fact]
+        public void FirstCharToLower_TurkishCulture_UsesInvariantCasing()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+                Assert.Equal("id", Utilities.FirstCharToLower("Id"));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+    }
+}

--- a/HitBtc/ApiResponse.cs
+++ b/HitBtc/ApiResponse.cs
@@ -10,156 +10,147 @@ namespace Hitbtc
 
         public static implicit operator List<Symbol>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<Symbol>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<Symbol>(response);
         }
 
         public static implicit operator Symbol(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<Symbol>(response);
+            return response == null ? null : Utilities.ConvertFromJson<Symbol>(response);
         }
 
         public static implicit operator List<Currency>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<Currency>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<Currency>(response);
         }
 
         public static implicit operator Currency(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<Currency>(response);
+            return response == null ? null : Utilities.ConvertFromJson<Currency>(response);
         }
 
         public static implicit operator List<Ticker>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<Ticker>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<Ticker>(response);
         }
 
         public static implicit operator Ticker(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<Ticker>(response);
+            return response == null ? null : Utilities.ConvertFromJson<Ticker>(response);
         }
 
         public static implicit operator Dictionary<string, Ticker>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasonArray(response);
+            return response == null ? null : Utilities.ConvertTickerDictionaryFromJson(response);
         }
 
         public static implicit operator Orderbook(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<Orderbook>(response);
+            return response == null ? null : Utilities.ConvertFromJson<Orderbook>(response);
         }
 
         public static implicit operator List<Candle>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<Candle>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<Candle>(response);
         }
 
         public static implicit operator List<Balance>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<Balance>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<Balance>(response);
         }
 
         public static implicit operator Fee(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<Fee>(response);
+            return response == null ? null : Utilities.ConvertFromJson<Fee>(response);
         }
 
         public static implicit operator List<Order>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<Order>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<Order>(response);
         }
 
         public static implicit operator Order(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<Order>(response);
+            return response == null ? null : Utilities.ConvertFromJson<Order>(response);
         }
 
         public static implicit operator List<Transaction>(ApiResponse response)
         {
-            if (response != null)
-            {
-                if (response.Content.Contains("message"))
-                {
-                    var error = Utilities.ConverFromJason<Error>(response);
-                    throw new Exception(error.ToString());
-                }
-                return Utilities.ConverFromJasons<Transaction>(response);
-            }
-            return null;
+            return response == null ? null : Utilities.ConvertListFromJson<Transaction>(response);
         }
 
         public static implicit operator Transaction(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<Transaction>(response);
+            return response == null ? null : Utilities.ConvertFromJson<Transaction>(response);
         }
 
         public static implicit operator IdObject(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<IdObject>(response);
+            return response == null ? null : Utilities.ConvertFromJson<IdObject>(response);
         }
 
         public static implicit operator AddressModel(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<AddressModel>(response);
+            return response == null ? null : Utilities.ConvertFromJson<AddressModel>(response);
         }
 
         public static implicit operator WithdrawConfirm(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<WithdrawConfirm>(response);
+            return response == null ? null : Utilities.ConvertFromJson<WithdrawConfirm>(response);
         }
 
         public static implicit operator List<Trade>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<Trade>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<Trade>(response);
         }
 
         public static implicit operator List<TradeHistory>(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJasons<TradeHistory>(response);
+            return response == null ? null : Utilities.ConvertListFromJson<TradeHistory>(response);
         }
 
         public static implicit operator SocketCurrency(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketCurrency>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketCurrency>(response);
         }
 
         public static implicit operator SocketCurrencies(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketCurrencies>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketCurrencies>(response);
         }
 
         public static implicit operator SocketSymbol(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketSymbol>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketSymbol>(response);
         }
 
         public static implicit operator SocketSymbols(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketSymbols>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketSymbols>(response);
         }
 
         public static implicit operator SocketTrades(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketTrades>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketTrades>(response);
         }
 
         public static implicit operator SocketSubscribe(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketSubscribe>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketSubscribe>(response);
         }
 
         public static implicit operator SocketOrder(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketOrder>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketOrder>(response);
         }
 
         public static implicit operator SocketOrderReplace(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketOrderReplace>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketOrderReplace>(response);
         }
 
         public static implicit operator SocketBalance(ApiResponse response)
         {
-            return response == null ? null : Utilities.ConverFromJason<SocketBalance>(response);
+            return response == null ? null : Utilities.ConvertFromJson<SocketBalance>(response);
         }
     }
 }

--- a/HitBtc/HitBtcCategories/RestAccount.cs
+++ b/HitBtc/HitBtcCategories/RestAccount.cs
@@ -60,19 +60,19 @@ namespace Hitbtc.HitBtcCategories
         public async Task<IdObject> PostWithraw(string currency, int amount, string address, string paymentId = null,
             string networkFee = null, bool includeFee = false, bool autoCommit = true)
         {
-            var request = new RestRequest("/api/2/account/crypto/withdraw");
+            var request = new RestRequest("/api/2/account/crypto/withdraw", Method.Post);
             if (!string.IsNullOrEmpty(currency))
-                request.AddParameter("currency", currency, ParameterType.UrlSegment);
+                request.AddParameter("currency", currency);
             if (amount > 0)
-                request.AddParameter("amount", amount, ParameterType.UrlSegment);
+                request.AddParameter("amount", amount);
             if (!string.IsNullOrEmpty(address))
-                request.AddParameter("address", address, ParameterType.UrlSegment);
+                request.AddParameter("address", address);
             if (!string.IsNullOrEmpty(paymentId))
-                request.AddParameter("paymentId", paymentId, ParameterType.UrlSegment);
+                request.AddParameter("paymentId", paymentId);
             if (!string.IsNullOrEmpty(networkFee))
-                request.AddParameter("networkFee", networkFee, ParameterType.UrlSegment);
-            request.AddParameter("includeFee", includeFee, ParameterType.UrlSegment);
-            request.AddParameter("autoCommit", autoCommit, ParameterType.UrlSegment);
+                request.AddParameter("networkFee", networkFee);
+            request.AddParameter("includeFee", includeFee);
+            request.AddParameter("autoCommit", autoCommit);
             return await _hitBtcRestApi.Execute(request);
         }
 
@@ -83,7 +83,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<WithdrawConfirm> PutWithraw(string withrawId)
         {
-            var request = new RestRequest("/api/2/account/crypto/withdraw/{id}");
+            var request = new RestRequest("/api/2/account/crypto/withdraw/{id}", Method.Put);
             request.AddParameter("id", withrawId, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -112,10 +112,10 @@ namespace Hitbtc.HitBtcCategories
         {
             var request = new RestRequest("/api/2/account/transfer", Method.Post);
             if (!string.IsNullOrEmpty(currency))
-                request.AddParameter("currency", currency, ParameterType.UrlSegment);
+                request.AddParameter("currency", currency);
             if (amount > 0)
-                request.AddParameter("amount", amount, ParameterType.UrlSegment);
-            request.AddParameter("type", type, ParameterType.UrlSegment);
+                request.AddParameter("amount", amount);
+            request.AddParameter("type", type.ToString());
             return await _hitBtcRestApi.Execute(request);
         }
 
@@ -147,17 +147,17 @@ namespace Hitbtc.HitBtcCategories
             var request = new RestRequest("/api/2/account/transactions/{id}", Method.Get);
             request.AddParameter("id", transactionId, ParameterType.UrlSegment);
             if (!string.IsNullOrEmpty(currency))
-                request.AddParameter("currency", currency, ParameterType.UrlSegment);
-            request.AddParameter("sort", sort.ToString(), ParameterType.UrlSegment);
-            request.AddParameter("by", by.ToString(), ParameterType.UrlSegment);
+                request.AddQueryParameter("currency", currency);
+            request.AddQueryParameter("sort", sort.ToString());
+            request.AddQueryParameter("by", by.ToString());
             if (!string.IsNullOrEmpty(from))
-                request.AddParameter("from", from, ParameterType.UrlSegment);
+                request.AddQueryParameter("from", from);
             if (!string.IsNullOrEmpty(till))
-                request.AddParameter("till", till, ParameterType.UrlSegment);
+                request.AddQueryParameter("till", till);
             if (limit > 0)
-                request.AddParameter("limit", limit, ParameterType.UrlSegment);
+                request.AddQueryParameter("limit", limit.ToString());
             if (offset > 0)
-                request.AddParameter("offset", offset, ParameterType.UrlSegment);
+                request.AddQueryParameter("offset", offset.ToString());
             return await _hitBtcRestApi.Execute(request);
         }
     }

--- a/HitBtc/HitBtcCategories/RestAccount.cs
+++ b/HitBtc/HitBtcCategories/RestAccount.cs
@@ -41,7 +41,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<AddressModel> PostAddress(string currency)
         {
-            var request = new RestRequest("/api/2/account/crypto/address/{currency}", Method.POST);
+            var request = new RestRequest("/api/2/account/crypto/address/{currency}", Method.Post);
             request.AddParameter("currency", currency, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -95,7 +95,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<WithdrawConfirm> DeleteWithraw(string withrawId)
         {
-            var request = new RestRequest("/api/2/account/crypto/withdraw/{id}", Method.DELETE);
+            var request = new RestRequest("/api/2/account/crypto/withdraw/{id}", Method.Delete);
             request.AddParameter("id", withrawId, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -110,7 +110,7 @@ namespace Hitbtc.HitBtcCategories
         public async Task<IdObject> PostTransfer(string currency, int amount,
             PublicEnum.EnTransferType type = PublicEnum.EnTransferType.bankToExchange)
         {
-            var request = new RestRequest("/api/2/account/transfer", Method.POST);
+            var request = new RestRequest("/api/2/account/transfer", Method.Post);
             if (!string.IsNullOrEmpty(currency))
                 request.AddParameter("currency", currency, ParameterType.UrlSegment);
             if (amount > 0)
@@ -144,7 +144,7 @@ namespace Hitbtc.HitBtcCategories
         public async Task<List<Transaction>> GetTransaction(string transactionId, string currency, string from, string till, int offset, int limit = 100,
             PublicEnum.EnSort sort = PublicEnum.EnSort.Desc, PublicEnum.EnBy by = PublicEnum.EnBy.timestamp)
         {
-            var request = new RestRequest("/api/2/account/transactions/{id}", Method.GET);
+            var request = new RestRequest("/api/2/account/transactions/{id}", Method.Get);
             request.AddParameter("id", transactionId, ParameterType.UrlSegment);
             if (!string.IsNullOrEmpty(currency))
                 request.AddParameter("currency", currency, ParameterType.UrlSegment);

--- a/HitBtc/HitBtcCategories/RestPublicData.cs
+++ b/HitBtc/HitBtcCategories/RestPublicData.cs
@@ -72,7 +72,7 @@ namespace Hitbtc.HitBtcCategories
             var period = enPeriod.ToString() == "Month" ? "1M" : enPeriod.ToString();
             var request = new RestRequest("api/2/public/candles/{symbol}");
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            request.AddParameter("period", period, ParameterType.UrlSegment);
+            request.AddQueryParameter("period", period);
             return await _hitBtcRestApi.Execute(request, false);
         }
     }

--- a/HitBtc/HitBtcCategories/RestPublicData.cs
+++ b/HitBtc/HitBtcCategories/RestPublicData.cs
@@ -53,9 +53,9 @@ namespace Hitbtc.HitBtcCategories
             var request = new RestRequest { Resource = "api/2/public/ticker/{symbol}" };
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
             if (limit > 0)
-                request.Parameters.Add(new Parameter("limit", limit, ParameterType.GetOrPost));
+                request.AddQueryParameter("limit", limit.ToString());
             if (!string.IsNullOrEmpty(period))
-                request.Parameters.Add(new Parameter("period", period, ParameterType.GetOrPost));
+                request.AddQueryParameter("period", period);
             return await _hitBtcRestApi.Execute(request, false);
         }
 
@@ -63,7 +63,7 @@ namespace Hitbtc.HitBtcCategories
         {
             var request = new RestRequest("api/2/public/orderbook/{symbol}");
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            request.Parameters.Add(new Parameter("limit", limit, ParameterType.GetOrPost));
+            request.AddQueryParameter("limit", limit.ToString());
             return await _hitBtcRestApi.Execute(request, false);
         }
 

--- a/HitBtc/HitBtcCategories/RestTrading.cs
+++ b/HitBtc/HitBtcCategories/RestTrading.cs
@@ -23,7 +23,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<List<Balance>> GetBalance()
         {
-            return await _hitBtcRestApi.Execute(new RestRequest("/api/2/trading/balance", Method.GET));
+            return await _hitBtcRestApi.Execute(new RestRequest("/api/2/trading/balance", Method.Get));
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<Fee> GetFee(string symbolName)
         {
-            var request = new RestRequest("/api/2/trading/fee/{symbol}", Method.GET);
+            var request = new RestRequest("/api/2/trading/fee/{symbol}", Method.Get);
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -46,7 +46,7 @@ namespace Hitbtc.HitBtcCategories
         //public async Task<List<Order>> GetOrders(string symbolName)
         public async Task<List<Order>> GetOrders(string symbolName)
         {
-            var request = new RestRequest("/api/2/order", Method.GET);
+            var request = new RestRequest("/api/2/order", Method.Get);
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -72,7 +72,7 @@ namespace Hitbtc.HitBtcCategories
             string price = null, string stopPrice = null, string expireTime = null,
             string clientOrderId = null, bool strictValidate = false)
         {
-            var request = new RestRequest("/api/2/order", Method.POST);
+            var request = new RestRequest("/api/2/order", Method.Post);
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
             request.AddParameter("quantity", quantity, ParameterType.UrlSegment);
             request.AddParameter("side", side, ParameterType.UrlSegment);
@@ -97,7 +97,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<List<Order>> DeleteOrders(string symbolName)
         {
-            var request = new RestRequest("/api/2/order", Method.DELETE);
+            var request = new RestRequest("/api/2/order", Method.Delete);
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -111,7 +111,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<Order> GetOrder(string clientOrderId, int wait = 0)
         {
-            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.GET);
+            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Get);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
             if (wait > 0)
                 request.AddParameter("wait", wait, ParameterType.UrlSegment);
@@ -138,7 +138,7 @@ namespace Hitbtc.HitBtcCategories
             PublicEnum.EnTradingTimeInForce timeInForce = PublicEnum.EnTradingTimeInForce.GTC,
             string price = null, string stopPrice = null, string expireTime = null, bool strictValidate = false)
         {
-            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.PUT);
+            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Put);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
             request.AddParameter("quantity", quantity, ParameterType.UrlSegment);
@@ -162,7 +162,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<Order> DeleteOrder(string clientOrderId)
         {
-            var request = new RestRequest("/api/2/order", Method.DELETE);
+            var request = new RestRequest("/api/2/order", Method.Delete);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -178,7 +178,7 @@ namespace Hitbtc.HitBtcCategories
         public async Task<Order> PatchOrder(string clientOrderId, string quantity, string requestClientId,
             string price = null)
         {
-            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.PATCH);
+            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Patch);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
             request.AddParameter("quantity", quantity, ParameterType.UrlSegment);
             request.AddParameter("requestClientId", requestClientId, ParameterType.UrlSegment);

--- a/HitBtc/HitBtcCategories/RestTrading.cs
+++ b/HitBtc/HitBtcCategories/RestTrading.cs
@@ -47,7 +47,7 @@ namespace Hitbtc.HitBtcCategories
         public async Task<List<Order>> GetOrders(string symbolName)
         {
             var request = new RestRequest("/api/2/order", Method.Get);
-            request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
+            request.AddQueryParameter("symbol", symbolName);
             return await _hitBtcRestApi.Execute(request);
         }
 
@@ -73,20 +73,20 @@ namespace Hitbtc.HitBtcCategories
             string clientOrderId = null, bool strictValidate = false)
         {
             var request = new RestRequest("/api/2/order", Method.Post);
-            request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            request.AddParameter("quantity", quantity, ParameterType.UrlSegment);
-            request.AddParameter("side", side, ParameterType.UrlSegment);
-            request.AddParameter("type", type, ParameterType.UrlSegment);
-            request.AddParameter("timeInForce", timeInForce, ParameterType.UrlSegment);
+            request.AddParameter("symbol", symbolName);
+            request.AddParameter("quantity", quantity);
+            request.AddParameter("side", side.ToString());
+            request.AddParameter("type", type.ToString());
+            request.AddParameter("timeInForce", timeInForce.ToString());
             if (!string.IsNullOrEmpty(price))
-                request.AddParameter("price", price, ParameterType.UrlSegment);
+                request.AddParameter("price", price);
             if (!string.IsNullOrEmpty(stopPrice))
-                request.AddParameter("stopPrice", stopPrice, ParameterType.UrlSegment);
+                request.AddParameter("stopPrice", stopPrice);
             if (!string.IsNullOrEmpty(expireTime))
-                request.AddParameter("expireTime", expireTime, ParameterType.UrlSegment);
+                request.AddParameter("expireTime", expireTime);
             if (!string.IsNullOrEmpty(clientOrderId))
-                request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
-            request.AddParameter("strictValidate", strictValidate, ParameterType.UrlSegment);
+                request.AddParameter("clientOrderId", clientOrderId);
+            request.AddParameter("strictValidate", strictValidate);
             return await _hitBtcRestApi.Execute(request);
         }
 
@@ -98,7 +98,7 @@ namespace Hitbtc.HitBtcCategories
         public async Task<List<Order>> DeleteOrders(string symbolName)
         {
             var request = new RestRequest("/api/2/order", Method.Delete);
-            request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
+            request.AddQueryParameter("symbol", symbolName);
             return await _hitBtcRestApi.Execute(request);
         }
 
@@ -114,7 +114,7 @@ namespace Hitbtc.HitBtcCategories
             var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Get);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
             if (wait > 0)
-                request.AddParameter("wait", wait, ParameterType.UrlSegment);
+                request.AddQueryParameter("wait", wait.ToString());
             return await _hitBtcRestApi.Execute(request);
         }
 
@@ -140,18 +140,18 @@ namespace Hitbtc.HitBtcCategories
         {
             var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Put);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
-            request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            request.AddParameter("quantity", quantity, ParameterType.UrlSegment);
-            request.AddParameter("side", side, ParameterType.UrlSegment);
-            request.AddParameter("type", type, ParameterType.UrlSegment);
-            request.AddParameter("timeInForce", timeInForce, ParameterType.UrlSegment);
+            request.AddParameter("symbol", symbolName);
+            request.AddParameter("quantity", quantity);
+            request.AddParameter("side", side.ToString());
+            request.AddParameter("type", type.ToString());
+            request.AddParameter("timeInForce", timeInForce.ToString());
             if (!string.IsNullOrEmpty(price))
-                request.AddParameter("price", price, ParameterType.UrlSegment);
+                request.AddParameter("price", price);
             if (!string.IsNullOrEmpty(stopPrice))
-                request.AddParameter("stopPrice", stopPrice, ParameterType.UrlSegment);
+                request.AddParameter("stopPrice", stopPrice);
             if (!string.IsNullOrEmpty(expireTime))
-                request.AddParameter("expireTime", expireTime, ParameterType.UrlSegment);
-            request.AddParameter("strictValidate", strictValidate, ParameterType.UrlSegment);
+                request.AddParameter("expireTime", expireTime);
+            request.AddParameter("strictValidate", strictValidate);
             return await _hitBtcRestApi.Execute(request);
         }
 
@@ -162,7 +162,7 @@ namespace Hitbtc.HitBtcCategories
         /// <returns></returns>
         public async Task<Order> DeleteOrder(string clientOrderId)
         {
-            var request = new RestRequest("/api/2/order", Method.Delete);
+            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Delete);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
             return await _hitBtcRestApi.Execute(request);
         }
@@ -180,10 +180,10 @@ namespace Hitbtc.HitBtcCategories
         {
             var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Patch);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
-            request.AddParameter("quantity", quantity, ParameterType.UrlSegment);
-            request.AddParameter("requestClientId", requestClientId, ParameterType.UrlSegment);
+            request.AddParameter("quantity", quantity);
+            request.AddParameter("requestClientId", requestClientId);
             if (!string.IsNullOrEmpty(price))
-                request.AddParameter("price", price, ParameterType.UrlSegment);
+                request.AddParameter("price", price);
             return await _hitBtcRestApi.Execute(request);
         }
     }

--- a/HitBtc/HitBtcCategories/RestTradingHistory.cs
+++ b/HitBtc/HitBtcCategories/RestTradingHistory.cs
@@ -30,20 +30,20 @@ namespace Hitbtc.HitBtcCategories
         {
             var request = new RestRequest("/api/2/history/trades");
             if (!string.IsNullOrEmpty(symoblName))
-                request.Parameters.Add(new Parameter("symbol", symoblName, ParameterType.GetOrPost));
+                request.AddQueryParameter("symbol", symoblName);
 
-            request.Parameters.Add(new Parameter("sort", sort.ToString(), ParameterType.GetOrPost));
+            request.AddQueryParameter("sort", sort.ToString());
 
-            request.Parameters.Add(new Parameter("by", by.ToString(), ParameterType.GetOrPost));
+            request.AddQueryParameter("by", by.ToString());
 
             if (!string.IsNullOrEmpty(from))
-                request.Parameters.Add(new Parameter("from", from, ParameterType.GetOrPost));
+                request.AddQueryParameter("from", from);
             if (!string.IsNullOrEmpty(till))
-                request.Parameters.Add(new Parameter("till", till, ParameterType.GetOrPost));
+                request.AddQueryParameter("till", till);
             if (offset > 0)
-                request.Parameters.Add(new Parameter("offset", offset, ParameterType.GetOrPost));
+                request.AddQueryParameter("offset", offset.ToString());
             if (limit > 0)
-                request.Parameters.Add(new Parameter("limit", limit, ParameterType.GetOrPost));
+                request.AddQueryParameter("limit", limit.ToString());
 
             return await _hitBtcRestApi.Execute(request);
         }
@@ -58,17 +58,17 @@ namespace Hitbtc.HitBtcCategories
 
             var request = new RestRequest("/api/2/history/order");
             if (!string.IsNullOrEmpty(symoblName))
-                request.Parameters.Add(new Parameter("symbol", symoblName, ParameterType.GetOrPost));
+                request.AddQueryParameter("symbol", symoblName);
             if (!string.IsNullOrEmpty(clientOrderId))
-                request.Parameters.Add(new Parameter("clientOrderId", clientOrderId, ParameterType.GetOrPost));
+                request.AddQueryParameter("clientOrderId", clientOrderId);
             if (!string.IsNullOrEmpty(from))
-                request.Parameters.Add(new Parameter("from", from, ParameterType.GetOrPost));
+                request.AddQueryParameter("from", from);
             if (!string.IsNullOrEmpty(till))
-                request.Parameters.Add(new Parameter("till", till, ParameterType.GetOrPost));
+                request.AddQueryParameter("till", till);
             if (offset > 0)
-                request.Parameters.Add(new Parameter("offset", offset, ParameterType.GetOrPost));
+                request.AddQueryParameter("offset", offset.ToString());
             if (limit > 0)
-                request.Parameters.Add(new Parameter("limit", limit, ParameterType.GetOrPost));
+                request.AddQueryParameter("limit", limit.ToString());
 
             return await _hitBtcRestApi.Execute(request);
         }

--- a/HitBtc/HitBtcRestApi.cs
+++ b/HitBtc/HitBtcRestApi.cs
@@ -44,21 +44,24 @@ namespace Hitbtc
             if (requireAuthentication && !IsAuthorized)
                 throw new Exception("AccessTokenInvalid");
 
-            var client = new RestClient(Url);
+            var options = new RestClientOptions(Url);
 
             if (requireAuthentication)
-                client.Authenticator = new HttpBasicAuthenticator(_apiKey, _secretKey);
+                options.Authenticator = new HttpBasicAuthenticator(_apiKey, _secretKey);
 
-            var response = await client.GetResponseAsync(request).ConfigureAwait(false);
-
-            if (response.ErrorException != null)
+            using (var client = new RestClient(options))
             {
-                const string message = "Error retrieving response.  Check inner details for more info.";
-                var exception = new ApplicationException(message, response.ErrorException);
-                throw exception;
-            }
+                var response = await client.ExecuteAsync(request).ConfigureAwait(false);
 
-            return new ApiResponse { Content = response.Content };
+                if (response.ErrorException != null)
+                {
+                    const string message = "Error retrieving response.  Check inner details for more info.";
+                    var exception = new ApplicationException(message, response.ErrorException);
+                    throw exception;
+                }
+
+                return new ApiResponse { Content = response.Content };
+            }
         }
 
         /// <summary>
@@ -78,30 +81,5 @@ namespace Hitbtc
             IsAuthorized = true;
         }
 
-    }
-    public static class RestClientExtensions
-    {
-        private static Task<T> SelectAsync<T>(this RestClient client, IRestRequest request,
-            Func<IRestResponse, T> selector)
-        {
-            var tcs = new TaskCompletionSource<T>();
-            var loginResponse = client.ExecuteAsync(request, r =>
-            {
-                if (r.ErrorException == null)
-                {
-                    tcs.SetResult(selector(r));
-                }
-                else
-                {
-                    tcs.SetException(r.ErrorException);
-                }
-            });
-            return tcs.Task;
-        }
-
-        public static Task<IRestResponse> GetResponseAsync(this RestClient client, IRestRequest request)
-        {
-            return client.SelectAsync(request, r => r);
-        }
     }
 }

--- a/HitBtc/HitBtcRestApi.cs
+++ b/HitBtc/HitBtcRestApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Threading;
 using Hitbtc.HitBtcCategories;
 using RestSharp;
 using RestSharp.Authenticators;
@@ -39,10 +40,25 @@ namespace Hitbtc
             Account = new RestAccount(this);
         }
 
-        public async Task<ApiResponse> Execute(RestRequest request, bool requireAuthentication = true)
+        public virtual Task<ApiResponse> Execute(RestRequest request, bool requireAuthentication = true)
         {
+            return ExecuteCore(request, requireAuthentication, CancellationToken.None);
+        }
+
+        /// <summary>Executes a REST request with cancellation support.</summary>
+        public virtual Task<ApiResponse> Execute(RestRequest request, bool requireAuthentication,
+            CancellationToken cancellationToken)
+        {
+            return ExecuteCore(request, requireAuthentication, cancellationToken);
+        }
+
+        private async Task<ApiResponse> ExecuteCore(RestRequest request, bool requireAuthentication,
+            CancellationToken cancellationToken)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
             if (requireAuthentication && !IsAuthorized)
-                throw new Exception("AccessTokenInvalid");
+                throw new InvalidOperationException("The request requires authorization. Call Authorize first.");
 
             var options = new RestClientOptions(Url);
 
@@ -51,13 +67,13 @@ namespace Hitbtc
 
             using (var client = new RestClient(options))
             {
-                var response = await client.ExecuteAsync(request).ConfigureAwait(false);
+                var response = await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
 
-                if (response.ErrorException != null)
+                if (response.ErrorException != null || !response.IsSuccessful)
                 {
-                    const string message = "Error retrieving response.  Check inner details for more info.";
-                    var exception = new ApplicationException(message, response.ErrorException);
-                    throw exception;
+                    var message = string.Format("HitBTC request failed with HTTP status {0} ({1}).",
+                        (int)response.StatusCode, response.StatusDescription);
+                    throw new ApplicationException(message, response.ErrorException);
                 }
 
                 return new ApiResponse { Content = response.Content };
@@ -76,6 +92,10 @@ namespace Hitbtc
         /// <param name="secretKey">Secret key from the Settings page.</param>
         public void Authorize(string apiKey, string secretKey)
         {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentException("API key cannot be empty.", nameof(apiKey));
+            if (string.IsNullOrWhiteSpace(secretKey))
+                throw new ArgumentException("Secret key cannot be empty.", nameof(secretKey));
             _apiKey = apiKey;
             _secretKey = secretKey;
             IsAuthorized = true;

--- a/HitBtc/HitBtcSocketApi.cs
+++ b/HitBtc/HitBtcSocketApi.cs
@@ -1,104 +1,154 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
+using System.IO;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Hitbtc.HitBtcCategories;
-using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Hitbtc
 {
-    /// <summary>
-    /// https://api.hitbtc.com/
-    /// Use JSON-RPC 2.0 over WebSocket connection as transport.
-    /// </summary>
-    public class HitBtcSocketApi
+    /// <summary>Provides JSON-RPC access to the HitBTC WebSocket API.</summary>
+    public class HitBtcSocketApi : IDisposable
     {
-        private const string Uri = "wss://api.hitbtc.com/api/2/ws";
-        private readonly ClientWebSocket _clientWebSocket;
+        private const string Endpoint = "wss://api.hitbtc.com/api/2/ws";
+        private const int ReceiveBufferSize = 8192;
+        private const int MaximumMessageSize = 1024 * 1024;
+        private readonly IWebSocketClient _clientWebSocket;
+        private readonly SemaphoreSlim _operationLock = new SemaphoreSlim(1, 1);
         private string _apiKey;
         private string _secretKey;
+        private bool _connectionAuthenticated;
+        private bool _disposed;
 
         public SocketMarketData MarketData { get; set; }
-        public SocketTrading Trading { set; get; }
+        public SocketTrading Trading { get; set; }
         public bool IsAuthorized { get; set; }
 
-        public HitBtcSocketApi() 
+        public HitBtcSocketApi() : this(new WebSocketClientAdapter()) { }
+
+        internal HitBtcSocketApi(IWebSocketClient clientWebSocket)
         {
+            _clientWebSocket = clientWebSocket ?? throw new ArgumentNullException(nameof(clientWebSocket));
             MarketData = new SocketMarketData(this);
             Trading = new SocketTrading(this);
-            _clientWebSocket = new ClientWebSocket();
         }
 
-        public async Task<ApiResponse> Execute(string request, bool requireAuthentication = true)
+        public Task<ApiResponse> Execute(string request, bool requireAuthentication = true) =>
+            Execute(request, requireAuthentication, CancellationToken.None);
+
+        /// <summary>
+        /// Sends one JSON-RPC request. Operations are serialized because receives on one socket cannot safely run concurrently.
+        /// </summary>
+        public async Task<ApiResponse> Execute(string request, bool requireAuthentication,
+            CancellationToken cancellationToken)
         {
+            ThrowIfDisposed();
+            if (string.IsNullOrWhiteSpace(request))
+                throw new ArgumentException("The JSON-RPC request cannot be empty.", nameof(request));
+            if (requireAuthentication && !IsAuthorized)
+                throw new InvalidOperationException("The request requires authorization. Call Authorize first.");
+
+            await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (requireAuthentication && !IsAuthorized)
-                    throw new Exception("AccessTokenInvalid");
+                await EnsureConnected(cancellationToken).ConfigureAwait(false);
+                if (requireAuthentication && !_connectionAuthenticated)
+                    await Authenticate(cancellationToken).ConfigureAwait(false);
 
-                await ConnectToServer();
-
-                if (requireAuthentication)
-                {
-                    var loginRequest =
-                        string.Format("{{ \"method\": \"login\", \"params\": {{ \"algo\": \"BASIC\", \"pKey\": \"{0}\", \"sKey\": \"{1}\"}} }}", _apiKey, _secretKey);
-                    await SendCommand(loginRequest);
-                    var reciveLoginData = await Receive();
-                }
-
-                await SendCommand(request);
-                var reciveData = await Receive();
-                return new ApiResponse { Content = reciveData };
+                await SendCommand(request, cancellationToken).ConfigureAwait(false);
+                return new ApiResponse { Content = await Receive(cancellationToken).ConfigureAwait(false) };
             }
-            catch (Exception e)
+            finally
             {
-                return null;
+                _operationLock.Release();
             }
         }
 
-
-        private async Task ConnectToServer()
+        private async Task EnsureConnected(CancellationToken cancellationToken)
         {
-            await _clientWebSocket.ConnectAsync(new Uri(Uri), CancellationToken.None).ConfigureAwait(false);
+            if (_clientWebSocket.State == WebSocketState.Open)
+                return;
+            if (_clientWebSocket.State != WebSocketState.None)
+                throw new WebSocketException("The WebSocket is not connectable: " + _clientWebSocket.State);
+            await _clientWebSocket.ConnectAsync(new Uri(Endpoint), cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task SendCommand(string jsonCmd)
+        private async Task Authenticate(CancellationToken cancellationToken)
         {
-            ArraySegment<byte> outputBuffer = new ArraySegment<byte>(Encoding.UTF8.GetBytes(jsonCmd));
-            await _clientWebSocket.SendAsync(outputBuffer, WebSocketMessageType.Text, true, CancellationToken.None)
-                .ConfigureAwait(false);
-        }
-
-        private async Task<string> Receive()
-        {
-            const int bufferSize = 8192;
-            var temporaryBuffer = new byte[bufferSize];
-            var buffer = new byte[bufferSize * 20];
-            int offset = 0;
-            while (true)
+            var loginRequest = new JObject
             {
-                var webSocketReceiveResult = await _clientWebSocket.ReceiveAsync(
-                    new ArraySegment<byte>(temporaryBuffer),
-                    CancellationToken.None).ConfigureAwait(false);
-                temporaryBuffer.CopyTo(buffer, offset);
-                offset += webSocketReceiveResult.Count;
-                temporaryBuffer = new byte[bufferSize];
-                if (webSocketReceiveResult.EndOfMessage)
+                ["method"] = "login",
+                ["params"] = new JObject
                 {
-                    break;
+                    ["algo"] = "BASIC",
+                    ["pKey"] = _apiKey,
+                    ["sKey"] = _secretKey
                 }
+            }.ToString(Newtonsoft.Json.Formatting.None);
+
+            await SendCommand(loginRequest, cancellationToken).ConfigureAwait(false);
+            var response = JObject.Parse(await Receive(cancellationToken).ConfigureAwait(false));
+            if (response["error"] != null || response["result"] == null)
+                throw new InvalidOperationException("HitBTC WebSocket authentication failed.");
+            _connectionAuthenticated = true;
+        }
+
+        private Task SendCommand(string jsonCommand, CancellationToken cancellationToken)
+        {
+            var bytes = Encoding.UTF8.GetBytes(jsonCommand);
+            return _clientWebSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true,
+                cancellationToken);
+        }
+
+        private async Task<string> Receive(CancellationToken cancellationToken)
+        {
+            var buffer = new byte[ReceiveBufferSize];
+            using (var message = new MemoryStream())
+            {
+                while (true)
+                {
+                    var result = await _clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken)
+                        .ConfigureAwait(false);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                        throw new WebSocketException("The server closed the WebSocket connection.");
+                    if (result.MessageType != WebSocketMessageType.Text)
+                        throw new WebSocketException("Only text WebSocket messages are supported.");
+
+                    message.Write(buffer, 0, result.Count);
+                    if (message.Length > MaximumMessageSize)
+                        throw new WebSocketException("The WebSocket message exceeded the 1 MiB safety limit.");
+                    if (result.EndOfMessage)
+                        break;
+                }
+                return Encoding.UTF8.GetString(message.ToArray());
             }
-            var resultJson = (new UTF8Encoding()).GetString(buffer);
-            return resultJson;
         }
 
         public void Authorize(string apiKey, string secretKey)
         {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentException("API key cannot be empty.", nameof(apiKey));
+            if (string.IsNullOrWhiteSpace(secretKey))
+                throw new ArgumentException("Secret key cannot be empty.", nameof(secretKey));
             _apiKey = apiKey;
             _secretKey = secretKey;
             IsAuthorized = true;
+            _connectionAuthenticated = false;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _clientWebSocket.Dispose();
+            _operationLock.Dispose();
+            _disposed = true;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(HitBtcSocketApi));
         }
     }
 }

--- a/HitBtc/Hitbtc.csproj
+++ b/HitBtc/Hitbtc.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PublicEnum.cs" />
     <Compile Include="Utilities.cs" />
+    <Compile Include="WebSocketClientAdapter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/HitBtc/Hitbtc.csproj
+++ b/HitBtc/Hitbtc.csproj
@@ -9,9 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hitbtc</RootNamespace>
     <AssemblyName>Hitbtc</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,14 +33,43 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=114.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.114.0.0\lib\net48\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -82,7 +113,15 @@
     <Compile Include="Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
+  </Target>
 </Project>

--- a/HitBtc/Properties/AssemblyInfo.cs
+++ b/HitBtc/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("HitBtc.Tests")]

--- a/HitBtc/Utilities.cs
+++ b/HitBtc/Utilities.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Hitbtc.HitBtcModel;
 using Newtonsoft.Json;
 
@@ -12,57 +11,42 @@ namespace Hitbtc
         {
             if (String.IsNullOrEmpty(input))
                 throw new ArgumentException("input parameter cannot be empty");
-            return input.First().ToString().ToLower() + input.Substring(1);
+            return char.ToLowerInvariant(input[0]) + input.Substring(1);
         }
 
-        public static T ConverFromJason<T>(ApiResponse response) where T : class, new()
+        public static T ConvertFromJson<T>(ApiResponse response) where T : class
         {
-            try
-            {
-                return JsonConvert.DeserializeObject<T>(response.Content);
-            }
-            catch (Exception)
-            {
-                return new T();
-            }
-        }
-
-        public static List<T> ConverFromJasons<T>(ApiResponse response) where T : class, new()
-        {
-            try
-            {
-                return JsonConvert.DeserializeObject<List<T>>(response.Content);
-            }
-            catch (Exception)
-            {
-                return new List<T>();
-            }
-        }
-
-        public static Dictionary<string, Ticker> ConverFromJasonArray(ApiResponse response)
-        {
-            Dictionary<string, Ticker> result = new Dictionary<string, Ticker>();
-            try
-            {
-                int length = response.Content.Trim().Length;
-                var tickers = response.Content.Trim()
-                    .Remove(length - 1)
-                    .Remove(0, 1)
-                    .Split(new[] { "}," }, StringSplitOptions.None).Select(x => x[x.Length - 1] != '}' ? x + "}" : x).ToList();
-
-                foreach (var ticker in tickers)
-                {
-                    int index = ticker.IndexOf(':');
-                    string name = ticker.Remove(index, ticker.Length - index);
-                    string data = ticker.Remove(0, index + 1);
-                    result.Add(name, JsonConvert.DeserializeObject<Ticker>(data));
-                }
-            }
-            catch (Exception)
-            {
-                // ignored
-            }
+            EnsureResponseContent(response);
+            var result = JsonConvert.DeserializeObject<T>(response.Content);
+            if (result == null)
+                throw new JsonSerializationException("The API response JSON contained no value.");
             return result;
+        }
+
+        public static List<T> ConvertListFromJson<T>(ApiResponse response) where T : class
+        {
+            EnsureResponseContent(response);
+            var result = JsonConvert.DeserializeObject<List<T>>(response.Content);
+            if (result == null)
+                throw new JsonSerializationException("The API response JSON contained no collection.");
+            return result;
+        }
+
+        public static Dictionary<string, Ticker> ConvertTickerDictionaryFromJson(ApiResponse response)
+        {
+            EnsureResponseContent(response);
+            var result = JsonConvert.DeserializeObject<Dictionary<string, Ticker>>(response.Content);
+            if (result == null)
+                throw new JsonSerializationException("The API response JSON contained no ticker dictionary.");
+            return result;
+        }
+
+        private static void EnsureResponseContent(ApiResponse response)
+        {
+            if (response == null)
+                throw new ArgumentNullException(nameof(response));
+            if (string.IsNullOrWhiteSpace(response.Content))
+                throw new JsonSerializationException("The API response body was empty.");
         }
     }
 }

--- a/HitBtc/WebSocketClientAdapter.cs
+++ b/HitBtc/WebSocketClientAdapter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hitbtc
+{
+    internal interface IWebSocketClient : IDisposable
+    {
+        WebSocketState State { get; }
+        Task ConnectAsync(Uri uri, CancellationToken cancellationToken);
+        Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
+            CancellationToken cancellationToken);
+        Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken);
+    }
+
+    internal sealed class WebSocketClientAdapter : IWebSocketClient
+    {
+        private readonly ClientWebSocket _client = new ClientWebSocket();
+        public WebSocketState State => _client.State;
+
+        public Task ConnectAsync(Uri uri, CancellationToken cancellationToken) =>
+            _client.ConnectAsync(uri, cancellationToken);
+
+        public Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
+            CancellationToken cancellationToken) =>
+            _client.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+
+        public Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer,
+            CancellationToken cancellationToken) => _client.ReceiveAsync(buffer, cancellationToken);
+
+        public void Dispose() => _client.Dispose();
+    }
+}

--- a/HitBtc/app.config
+++ b/HitBtc/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/HitBtc/packages.config
+++ b/HitBtc/packages.config
@@ -1,5 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net452" />
-  <package id="RestSharp" version="106.10.1" targetFramework="net452" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
+  <package id="RestSharp" version="114.0.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.6.1" targetFramework="net48" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net48" />
+  <package id="System.Memory" version="4.6.3" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net48" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.6.2" targetFramework="net48" />
 </packages>

--- a/Hitbtc.sln
+++ b/Hitbtc.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hitbtc", "HitBtc\Hitbtc.csproj", "{D5BBADDF-077F-4028-B53C-8560178E89DC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HitBtc.Tests", "HitBtc.Tests\HitBtc.Tests.csproj", "{F02A96AC-A87A-4ADF-B74D-75FD84F52D96}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{D5BBADDF-077F-4028-B53C-8560178E89DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5BBADDF-077F-4028-B53C-8560178E89DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5BBADDF-077F-4028-B53C-8560178E89DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F02A96AC-A87A-4ADF-B74D-75FD84F52D96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F02A96AC-A87A-4ADF-B74D-75FD84F52D96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F02A96AC-A87A-4ADF-B74D-75FD84F52D96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F02A96AC-A87A-4ADF-B74D-75FD84F52D96}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -34,14 +34,3 @@ var hitBtcSocketApi = new HitBtcSocketApi();
 var response = await hitBtcSocketApi.MarketData.UnsubscribeCandles("BTCUSD");
 
 ```
-
-## Donate
-If you find this tool useful, you can show you support with a kind donation:
-
-**ETH**: 0x4e135a99630a391b71979a57f34f85ad28a1a1ef\
-**LTC**: LLgZmzfLA6uLTVqCfZBHub3C3dhjBbMxk2\
-**BTC**: 3QuChD5q4FXU8iW3zCsCV6GJvcJegAvTsi
-
-Thank you.
-
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hitbtc
 HitBTC Websocket API 2.0 Client written in C#.\
 A full-featured .NET **[Hitbtc API](https://api.hitbtc.com)** designed for ease of use.\
-Compatible with **.NET 4.5.1, .NET 4.5.2, .NET 4.6.1, .NETSTANDARD 2.0**
+Compatible with **.NET 4.5.1, .NET 4.5.2, .NET 4.6.1, .NET STANDARD 2.0**
 
 
 ## Getting Started

--- a/Test/App.config
+++ b/Test/App.config
@@ -1,6 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Test/Properties/Resources.Designer.cs
+++ b/Test/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Test.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Test/Properties/Settings.Designer.cs
+++ b/Test/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Test.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -8,10 +8,13 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>Test</RootNamespace>
     <AssemblyName>Test</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,8 +36,41 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=114.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.114.0.0\lib\net48\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -68,6 +104,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -88,4 +125,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
+  </Target>
 </Project>

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net48" />
+  <package id="RestSharp" version="114.0.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.6.1" targetFramework="net48" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net48" />
+  <package id="System.Memory" version="4.6.3" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net48" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.6.2" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
## Summary

This pull request improves the reliability, correctness, and testability of the HitBTC client library.

## Changes

- Updated NuGet dependencies and upgraded projects to .NET Framework 4.8
- Added an automated xUnit test project
- Fixed REST request methods, paths, query parameters, and request bodies
- Improved REST authorization and HTTP error handling
- Replaced fragile manual JSON parsing with Newtonsoft.Json
- Prevented malformed or empty responses from silently producing empty models
- Improved WebSocket connection reuse and lifecycle management
- Added support for fragmented UTF-8 messages and cancellation
- Added explicit WebSocket authentication and connection error handling
- Added a GitHub Actions workflow for build, test, and Release DLL generation

## Testing

- Debug build: passed with 0 warnings and 0 errors
- Release build: passed with 0 warnings and 0 errors
- Automated tests: 38 passed, 0 failed
- Tests do not require real API credentials or external HitBTC connectivity

## Notes

Some breaking improvements, such as correcting public model property types and renaming misspelled public APIs, were intentionally deferred to a future major release.