### PR TITLE
Develop

### DIFF
--- a/HitBtc.Tests/ApiResponseTests.cs
+++ b/HitBtc.Tests/ApiResponseTests.cs
@@ -12,7 +12,7 @@ namespace Hitbtc.Tests
         {
             var response = new ApiResponse
             {
-                Content = "{\"id\":\"BTCUSD\",\"baseCurrency\":\"BTC\",\"quoteCurrency\":\"USD\"}"
+                Content = "{\"id\":\"BTCUSD\",\"base_currency\":\"BTC\",\"quote_currency\":\"USD\"}"
             };
 
             Symbol symbol = response;
@@ -91,6 +91,53 @@ namespace Hitbtc.Tests
 
             Assert.Equal("100.5", tickers["BTCUSD"].Last);
             Assert.Equal("20.1", tickers["ETHUSD"].Last);
+        }
+
+        [Fact]
+        public void OrderBookConversion_DeserializesV3PriceSizeArrays()
+        {
+            var response = new ApiResponse
+            {
+                Content = "{\"ask\":[[\"101\",\"0.5\"]],\"bid\":[[\"100\",\"1.25\"]],\"timestamp\":\"2026-01-01T00:00:00.000Z\"}"
+            };
+
+            Orderbook orderbook = response;
+
+            Assert.Equal("101", orderbook.Ask[0].Price);
+            Assert.Equal("0.5", orderbook.Ask[0].Size);
+            Assert.Equal("100", orderbook.Bid[0].Price);
+        }
+
+        [Fact]
+        public void V3SnakeCaseFields_AreMappedToModels()
+        {
+            var response = new ApiResponse
+            {
+                Content = "{\"client_order_id\":\"client-1\",\"time_in_force\":\"GTC\",\"quantity_cumulative\":\"0.2\",\"created_at\":\"now\"}"
+            };
+
+            Order order = response;
+
+            Assert.Equal("client-1", order.ClientOrderId);
+            Assert.Equal("GTC", order.TimeInForce);
+            Assert.Equal("0.2", order.CumQuantity);
+            Assert.Equal("now", order.CreatedAt);
+        }
+
+        [Fact]
+        public void CurrencyConversion_MapsV3NetworkAndDecimalPrecision()
+        {
+            var response = new ApiResponse
+            {
+                Content = "{\"full_name\":\"Bitcoin\",\"precision_transfer\":\"0.00000001\",\"networks\":[{\"code\":\"BTC\",\"network_name\":\"Bitcoin\",\"precision_payout\":\"0.00000001\"}]}"
+            };
+
+            Currency currency = response;
+
+            Assert.Equal("Bitcoin", currency.FullName);
+            Assert.Equal("0.00000001", currency.PrecisionTransfer);
+            Assert.Equal("BTC", currency.Networks[0].Code);
+            Assert.Equal("0.00000001", currency.Networks[0].PrecisionPayout);
         }
 
         [Fact]

--- a/HitBtc.Tests/ApiResponseTests.cs
+++ b/HitBtc.Tests/ApiResponseTests.cs
@@ -109,6 +109,17 @@ namespace Hitbtc.Tests
         }
 
         [Fact]
+        public void OrderBookConversion_MissingSize_ThrowsJsonSerializationException()
+        {
+            var response = new ApiResponse { Content = "{\"ask\":[[\"101\"]],\"bid\":[]}" };
+
+            Assert.Throws<JsonSerializationException>(() =>
+            {
+                Orderbook orderbook = response;
+            });
+        }
+
+        [Fact]
         public void V3SnakeCaseFields_AreMappedToModels()
         {
             var response = new ApiResponse

--- a/HitBtc.Tests/HitBtcRestApiTests.cs
+++ b/HitBtc.Tests/HitBtcRestApiTests.cs
@@ -36,7 +36,7 @@ namespace Hitbtc.Tests
         public async Task Execute_AuthenticatedRequestWithoutAuthorization_ThrowsBeforeNetworkCall()
         {
             var api = new HitBtcRestApi();
-            var request = new RestRequest("/api/2/trading/balance", Method.Get);
+            var request = new RestRequest("/api/3/spot/balance", Method.Get);
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => api.Execute(request));
 

--- a/HitBtc.Tests/HitBtcSocketApiTests.cs
+++ b/HitBtc.Tests/HitBtcSocketApiTests.cs
@@ -132,9 +132,64 @@ namespace Hitbtc.Tests
             using (var api = new HitBtcSocketApi(socket))
             {
                 api.Authorize("key", "secret");
-                var error = await Assert.ThrowsAsync<InvalidOperationException>(() => api.Execute("{}"));
-                Assert.Contains("authentication failed", error.Message);
+                var error = await Assert.ThrowsAsync<HitBtcWebSocketException>(() => api.Execute("{}"));
+                Assert.Contains("invalid", error.Message);
             }
+        }
+
+        [Fact]
+        public async Task Execute_ErrorResponse_ThrowsTypedExceptionWithApiCode()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueText("{\"error\":{\"code\":\"2001\",\"message\":\"bad request\"},\"id\":4}");
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                var error = await Assert.ThrowsAsync<HitBtcWebSocketException>(
+                    () => api.Execute("{\"id\":4}", false));
+                Assert.Equal("2001", error.ApiErrorCode);
+                Assert.Contains("bad request", error.Message);
+            }
+        }
+
+        [Fact]
+        public async Task Execute_MalformedResponse_ThrowsTypedException()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueText("not-json");
+            using (var api = new HitBtcSocketApi(socket))
+                await Assert.ThrowsAsync<HitBtcWebSocketException>(() => api.Execute("{}", false));
+        }
+
+        [Fact]
+        public async Task Execute_MalformedRequest_ThrowsBeforeConnecting()
+        {
+            var socket = new FakeWebSocketClient();
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                await Assert.ThrowsAsync<ArgumentException>(() => api.Execute("not-json", false));
+                Assert.Equal(0, socket.ConnectCount);
+            }
+        }
+
+        [Fact]
+        public async Task Execute_MismatchedResponseId_ThrowsInsteadOfReturningWrongResponse()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueText("{\"result\":true,\"id\":2}");
+            using (var api = new HitBtcSocketApi(socket))
+                await Assert.ThrowsAsync<HitBtcWebSocketException>(
+                    () => api.Execute("{\"id\":1}", false));
+        }
+
+        [Fact]
+        public async Task Execute_MessageOverSafetyLimit_ThrowsWebSocketException()
+        {
+            var socket = new FakeWebSocketClient();
+            var chunk = new string('x', 8192);
+            for (var index = 0; index < 128; index++) socket.EnqueueFragment(chunk, false);
+            socket.EnqueueFragment("x", true);
+            using (var api = new HitBtcSocketApi(socket))
+                await Assert.ThrowsAsync<WebSocketException>(() => api.Execute("{}", false));
         }
 
         [Fact]
@@ -173,6 +228,7 @@ namespace Hitbtc.Tests
                 for (var i = 0; i < parts.Length; i++) Enqueue(parts[i], WebSocketMessageType.Text, i == parts.Length - 1);
             }
             public void EnqueueClose() => Enqueue("", WebSocketMessageType.Close, true);
+            public void EnqueueFragment(string text, bool end) => Enqueue(text, WebSocketMessageType.Text, end);
             private void Enqueue(string text, WebSocketMessageType type, bool end) =>
                 _fragments.Enqueue(new Fragment(Encoding.UTF8.GetBytes(text), type, end));
 

--- a/HitBtc.Tests/HitBtcSocketApiTests.cs
+++ b/HitBtc.Tests/HitBtcSocketApiTests.cs
@@ -69,6 +69,42 @@ namespace Hitbtc.Tests
                 await api.Execute("{\"id\":2}", false);
                 Assert.Equal(1, socket.ConnectCount);
                 Assert.Equal(2, socket.SentMessages.Count);
+                Assert.Equal("wss://api.hitbtc.com/api/3/ws/public", socket.ConnectedUri.ToString());
+            }
+        }
+
+        [Fact]
+        public async Task SubscribeTicker_UsesV3ChannelProtocol()
+        {
+            var socket = new FakeWebSocketClient();
+            socket.EnqueueText("{\"result\":\"ok\",\"id\":7}");
+            using (var api = new HitBtcSocketApi(socket))
+            {
+                await api.MarketData.SubscribeTicker("BTCUSDT", 7);
+
+                var request = socket.SentMessages.Single();
+                Assert.Contains("\"method\":\"subscribe\"", request);
+                Assert.Contains("\"ch\":\"ticker/1s\"", request);
+                Assert.Contains("\"symbols\":[\"BTCUSDT\"]", request);
+            }
+        }
+
+        [Fact]
+        public async Task TradingCommand_UsesTradingEndpointAndSnakeCaseMethod()
+        {
+            var publicSocket = new FakeWebSocketClient();
+            var tradingSocket = new FakeWebSocketClient();
+            tradingSocket.EnqueueText("{\"result\":true}");
+            tradingSocket.EnqueueText("{\"result\":{},\"id\":9}");
+            using (var api = new HitBtcSocketApi(publicSocket, tradingSocket))
+            {
+                api.Authorize("key", "secret");
+                await api.Trading.NewOrder("BTCUSDT", "client-9", "0.01", "100", 9);
+
+                Assert.Equal("wss://api.hitbtc.com/api/3/ws/trading", tradingSocket.ConnectedUri.ToString());
+                Assert.Contains("\"method\":\"spot_new_order\"", tradingSocket.SentMessages.Last());
+                Assert.Contains("\"client_order_id\":\"client-9\"", tradingSocket.SentMessages.Last());
+                Assert.Equal(0, publicSocket.ConnectCount);
             }
         }
 
@@ -128,6 +164,7 @@ namespace Hitbtc.Tests
             private readonly Queue<Fragment> _fragments = new Queue<Fragment>();
             public WebSocketState State { get; private set; } = WebSocketState.None;
             public int ConnectCount { get; private set; }
+            public Uri ConnectedUri { get; private set; }
             public List<string> SentMessages { get; } = new List<string>();
 
             public void EnqueueText(string text) => Enqueue(text, WebSocketMessageType.Text, true);
@@ -141,7 +178,7 @@ namespace Hitbtc.Tests
 
             public Task ConnectAsync(Uri uri, CancellationToken token)
             {
-                token.ThrowIfCancellationRequested(); ConnectCount++; State = WebSocketState.Open; return Task.CompletedTask;
+                token.ThrowIfCancellationRequested(); ConnectCount++; ConnectedUri = uri; State = WebSocketState.Open; return Task.CompletedTask;
             }
             public Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType type, bool end, CancellationToken token)
             {

--- a/HitBtc.Tests/RestRequestConstructionTests.cs
+++ b/HitBtc.Tests/RestRequestConstructionTests.cs
@@ -15,10 +15,12 @@ namespace Hitbtc.Tests
             await api.Account.PostWithraw("BTC", 2, "wallet-address");
 
             Assert.Equal(Method.Post, api.Request.Method);
-            Assert.Equal("/api/2/account/crypto/withdraw", api.Request.Resource);
+            Assert.Equal("/api/3/wallet/crypto/withdraw", api.Request.Resource);
             AssertParameter(api.Request, "currency", "BTC", ParameterType.GetOrPost);
             AssertParameter(api.Request, "amount", "2", ParameterType.GetOrPost);
             AssertParameter(api.Request, "address", "wallet-address", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "include_fee", "false", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "auto_commit", "true", ParameterType.GetOrPost);
         }
 
         [Fact]
@@ -40,9 +42,12 @@ namespace Hitbtc.Tests
             await api.Trading.PostOrders("BTCUSD", "1.5", price: "100");
 
             Assert.Equal(Method.Post, api.Request.Method);
+            Assert.Equal("/api/3/spot/order", api.Request.Resource);
             AssertParameter(api.Request, "symbol", "BTCUSD", ParameterType.GetOrPost);
             AssertParameter(api.Request, "quantity", "1.5", ParameterType.GetOrPost);
             AssertParameter(api.Request, "price", "100", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "time_in_force", "GTC", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "strict_validate", "false", ParameterType.GetOrPost);
         }
 
         [Fact]
@@ -53,7 +58,7 @@ namespace Hitbtc.Tests
             await api.Trading.DeleteOrder("client-1");
 
             Assert.Equal(Method.Delete, api.Request.Method);
-            Assert.Equal("/api/2/order/{clientOrderId}", api.Request.Resource);
+            Assert.Equal("/api/3/spot/order/{clientOrderId}", api.Request.Resource);
             AssertParameter(api.Request, "clientOrderId", "client-1", ParameterType.UrlSegment);
         }
 
@@ -79,6 +84,42 @@ namespace Hitbtc.Tests
             AssertParameter(api.Request, "period", "H4", ParameterType.QueryString);
         }
 
+        [Fact]
+        public async Task GetPublicSymbols_UsesV3EndpointAndDictionaryResponse()
+        {
+            var api = new CapturingRestApi("{\"BTCUSDT\":{\"base_currency\":\"BTC\",\"quote_currency\":\"USDT\"}}");
+
+            var symbols = await api.PublicData.GetSymbol();
+
+            Assert.Equal("/api/3/public/symbol", api.Request.Resource);
+            Assert.False(api.RequireAuthentication);
+            Assert.Equal("BTCUSDT", symbols[0].Id);
+        }
+
+        [Fact]
+        public async Task TradeHistory_UsesV3EndpointAndSnakeCaseOrderId()
+        {
+            var api = new CapturingRestApi("[]");
+
+            await api.TradingHistory.GetTradersByOrder("42");
+
+            Assert.Equal("/api/3/spot/history/trade", api.Request.Resource);
+            AssertParameter(api.Request, "order_id", "42", ParameterType.QueryString);
+        }
+
+        [Fact]
+        public async Task Transfer_MapsLegacyDirectionToV3WalletAndSpotAccounts()
+        {
+            var api = new CapturingRestApi("[\"transfer-1\"]");
+
+            var result = await api.Account.PostTransfer("BTC", 2);
+
+            Assert.Equal("transfer-1", result.Id);
+            Assert.Equal("/api/3/wallet/transfer", api.Request.Resource);
+            AssertParameter(api.Request, "source", "wallet", ParameterType.GetOrPost);
+            AssertParameter(api.Request, "destination", "spot", ParameterType.GetOrPost);
+        }
+
         private static void AssertParameter(RestRequest request, string name, string value, ParameterType type)
         {
             var parameter = request.Parameters.Single(item => item.Name == name);
@@ -96,10 +137,12 @@ namespace Hitbtc.Tests
             }
 
             public RestRequest Request { get; private set; }
+            public bool RequireAuthentication { get; private set; }
 
             public override Task<ApiResponse> Execute(RestRequest request, bool requireAuthentication = true)
             {
                 Request = request;
+                RequireAuthentication = requireAuthentication;
                 return Task.FromResult(new ApiResponse { Content = _content });
             }
         }

--- a/HitBtc.Tests/RestRequestConstructionTests.cs
+++ b/HitBtc.Tests/RestRequestConstructionTests.cs
@@ -12,7 +12,7 @@ namespace Hitbtc.Tests
         {
             var api = new CapturingRestApi("{}");
 
-            await api.Account.PostWithraw("BTC", 2, "wallet-address");
+            await api.Account.PostWithdraw("BTC", "2", "wallet-address");
 
             Assert.Equal(Method.Post, api.Request.Method);
             Assert.Equal("/api/3/wallet/crypto/withdraw", api.Request.Resource);
@@ -28,7 +28,7 @@ namespace Hitbtc.Tests
         {
             var api = new CapturingRestApi("{}");
 
-            await api.Account.PutWithraw("withdraw-1");
+            await api.Account.PutWithdraw("withdraw-1");
 
             Assert.Equal(Method.Put, api.Request.Method);
             AssertParameter(api.Request, "id", "withdraw-1", ParameterType.UrlSegment);
@@ -118,6 +118,30 @@ namespace Hitbtc.Tests
             Assert.Equal("/api/3/wallet/transfer", api.Request.Resource);
             AssertParameter(api.Request, "source", "wallet", ParameterType.GetOrPost);
             AssertParameter(api.Request, "destination", "spot", ParameterType.GetOrPost);
+        }
+
+        [Fact]
+        public async Task LegacyWithdraw_WithNetworkFee_RejectsUnsupportedFinancialParameter()
+        {
+            var api = new CapturingRestApi("{}");
+
+#pragma warning disable 618
+            await Assert.ThrowsAsync<System.NotSupportedException>(() =>
+                api.Account.PostWithraw("BTC", 2, "address", networkFee: "0.01"));
+#pragma warning restore 618
+
+            Assert.Null(api.Request);
+        }
+
+        [Fact]
+        public async Task TransactionById_WithLegacyFilters_RejectsIgnoredParameters()
+        {
+            var api = new CapturingRestApi("{}");
+
+            await Assert.ThrowsAsync<System.NotSupportedException>(() =>
+                api.Account.GetTransaction("tx-1", "BTC", null, null, 0));
+
+            Assert.Null(api.Request);
         }
 
         private static void AssertParameter(RestRequest request, string name, string value, ParameterType type)

--- a/HitBtc.Tests/RestTransportTests.cs
+++ b/HitBtc.Tests/RestTransportTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using RestSharp;
+using Xunit;
+
+namespace Hitbtc.Tests
+{
+    public class RestTransportTests
+    {
+        [Fact]
+        public async Task Execute_PublicSuccess_ReturnsContentWithoutAuthenticator()
+        {
+            var transport = new FakeRestTransport(new RestResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                IsSuccessStatusCode = true,
+                ResponseStatus = ResponseStatus.Completed,
+                Content = "{\"last\":\"1\"}"
+            });
+            var api = new HitBtcRestApi(transport);
+
+            var response = await api.Execute(new RestRequest("/api/3/public/ticker/BTCUSDT"), false);
+
+            Assert.Equal("{\"last\":\"1\"}", response.Content);
+            Assert.Null(transport.Options.Authenticator);
+        }
+
+        [Fact]
+        public async Task Execute_AuthorizedRequest_ConfiguresAuthenticator()
+        {
+            var transport = SuccessfulTransport();
+            var api = new HitBtcRestApi(transport);
+            api.Authorize("key", "secret");
+
+            await api.Execute(new RestRequest("/api/3/spot/balance"));
+
+            Assert.NotNull(transport.Options.Authenticator);
+        }
+
+        [Fact]
+        public async Task Execute_ApiError_ThrowsTypedExceptionWithStatusAndCode()
+        {
+            var transport = new FakeRestTransport(new RestResponse
+            {
+                StatusCode = (HttpStatusCode)429,
+                ResponseStatus = ResponseStatus.Completed,
+                Content = "{\"error\":{\"code\":\"429\",\"message\":\"rate limit\"}}"
+            });
+            var api = new HitBtcRestApi(transport);
+
+            var error = await Assert.ThrowsAsync<HitBtcApiException>(
+                () => api.Execute(new RestRequest("/api/3/public/ticker"), false));
+
+            Assert.Equal((HttpStatusCode)429, error.StatusCode);
+            Assert.Equal("429", error.ApiErrorCode);
+            Assert.Contains("rate limit", error.Message);
+        }
+
+        [Fact]
+        public async Task Execute_TransportFailure_PreservesInnerException()
+        {
+            var cause = new TimeoutException("transport timeout");
+            var transport = new FakeRestTransport(new RestResponse
+            {
+                ResponseStatus = ResponseStatus.TimedOut,
+                ErrorException = cause
+            });
+            var api = new HitBtcRestApi(transport);
+
+            var error = await Assert.ThrowsAsync<HitBtcApiException>(
+                () => api.Execute(new RestRequest("/api/3/public/ticker"), false));
+
+            Assert.Same(cause, error.InnerException);
+        }
+
+        [Fact]
+        public async Task Execute_CancelledToken_DoesNotInvokeTransport()
+        {
+            var transport = SuccessfulTransport();
+            var api = new HitBtcRestApi(transport);
+            using (var source = new CancellationTokenSource())
+            {
+                source.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                    api.Execute(new RestRequest("/api/3/public/ticker"), false, source.Token));
+            }
+            Assert.Equal(0, transport.CallCount);
+        }
+
+        [Fact]
+        public void IsAuthorized_PublicSetter_IsNotExposed()
+        {
+            var restSetter = typeof(HitBtcRestApi).GetProperty("IsAuthorized").SetMethod;
+            var socketSetter = typeof(HitBtcSocketApi).GetProperty("IsAuthorized").SetMethod;
+
+            Assert.True(restSetter.IsPrivate);
+            Assert.True(socketSetter.IsPrivate);
+        }
+
+        private static FakeRestTransport SuccessfulTransport()
+        {
+            return new FakeRestTransport(new RestResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                IsSuccessStatusCode = true,
+                ResponseStatus = ResponseStatus.Completed,
+                Content = "{}"
+            });
+        }
+
+        private sealed class FakeRestTransport : IRestTransport
+        {
+            private readonly RestResponse _response;
+            public FakeRestTransport(RestResponse response) { _response = response; }
+            public RestClientOptions Options { get; private set; }
+            public int CallCount { get; private set; }
+
+            public Task<RestResponse> ExecuteAsync(RestRequest request, RestClientOptions options,
+                CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CallCount++;
+                Options = options;
+                return Task.FromResult(_response);
+            }
+        }
+    }
+}

--- a/HitBtc/HitBtcApiException.cs
+++ b/HitBtc/HitBtcApiException.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net;
+
+namespace Hitbtc
+{
+    /// <summary>Represents an error returned by HitBTC or its transport.</summary>
+    public sealed class HitBtcApiException : Exception
+    {
+        public HitBtcApiException(string message, HttpStatusCode statusCode = 0,
+            string apiErrorCode = null, Exception innerException = null)
+            : base(message, innerException)
+        {
+            StatusCode = statusCode;
+            ApiErrorCode = apiErrorCode;
+        }
+
+        /// <summary>Gets the HTTP status code, or zero when no HTTP response was received.</summary>
+        public HttpStatusCode StatusCode { get; }
+
+        /// <summary>Gets the exchange-specific error code when the response supplied one.</summary>
+        public string ApiErrorCode { get; }
+    }
+
+    /// <summary>Represents a malformed or error response received over WebSocket.</summary>
+    public sealed class HitBtcWebSocketException : Exception
+    {
+        public HitBtcWebSocketException(string message, string apiErrorCode = null,
+            Exception innerException = null) : base(message, innerException)
+        {
+            ApiErrorCode = apiErrorCode;
+        }
+
+        public string ApiErrorCode { get; }
+    }
+}

--- a/HitBtc/HitBtcCategories/RestAccount.cs
+++ b/HitBtc/HitBtcCategories/RestAccount.cs
@@ -34,10 +34,13 @@ namespace Hitbtc.HitBtcCategories
             return await _api.Execute(request);
         }
 
+        [System.Obsolete("Use PostWithdraw. API v3 does not accept networkFee.")]
         public Task<IdObject> PostWithraw(string currency, int amount, string address,
             string paymentId = null, string networkFee = null, bool includeFee = false,
             bool autoCommit = true)
         {
+            if (!string.IsNullOrWhiteSpace(networkFee))
+                throw new System.NotSupportedException("HitBTC API v3 does not accept networkFee. Select a network with PostWithdraw instead.");
             return PostWithdraw(currency, amount.ToString(CultureInfo.InvariantCulture), address,
                 paymentId, null, includeFee, autoCommit);
         }
@@ -58,14 +61,26 @@ namespace Hitbtc.HitBtcCategories
             return await _api.Execute(request);
         }
 
-        public async Task<WithdrawConfirm> PutWithraw(string withrawId)
+        [System.Obsolete("Use PutWithdraw.")]
+        public Task<WithdrawConfirm> PutWithraw(string withrawId)
         {
-            return await _api.Execute(WithdrawalRequest(withrawId, Method.Put));
+            return PutWithdraw(withrawId);
         }
 
-        public async Task<WithdrawConfirm> DeleteWithraw(string withrawId)
+        public async Task<WithdrawConfirm> PutWithdraw(string withdrawalId)
         {
-            return await _api.Execute(WithdrawalRequest(withrawId, Method.Delete));
+            return await _api.Execute(WithdrawalRequest(withdrawalId, Method.Put));
+        }
+
+        [System.Obsolete("Use DeleteWithdraw.")]
+        public Task<WithdrawConfirm> DeleteWithraw(string withrawId)
+        {
+            return DeleteWithdraw(withrawId);
+        }
+
+        public async Task<WithdrawConfirm> DeleteWithdraw(string withdrawalId)
+        {
+            return await _api.Execute(WithdrawalRequest(withdrawalId, Method.Delete));
         }
 
         public async Task<IdObject> PostTransfer(string currency, int amount,
@@ -91,10 +106,19 @@ namespace Hitbtc.HitBtcCategories
             PublicEnum.EnSort sort = PublicEnum.EnSort.Desc,
             PublicEnum.EnBy by = PublicEnum.EnBy.timestamp)
         {
+            if (!string.IsNullOrWhiteSpace(currency) || !string.IsNullOrWhiteSpace(from) ||
+                !string.IsNullOrWhiteSpace(till) || offset != 0 || limit != 100 ||
+                sort != PublicEnum.EnSort.Desc || by != PublicEnum.EnBy.timestamp)
+                throw new System.NotSupportedException("HitBTC API v3 does not support filters when retrieving a transaction by ID.");
+
+            return new List<Transaction> { await GetTransaction(transactionId) };
+        }
+
+        public async Task<Transaction> GetTransaction(string transactionId)
+        {
             var request = new RestRequest("/api/3/wallet/transactions/{id}");
             request.AddParameter("id", transactionId, ParameterType.UrlSegment);
-            Transaction transaction = await _api.Execute(request);
-            return new List<Transaction> { transaction };
+            return await _api.Execute(request);
         }
 
         private static RestRequest WithdrawalRequest(string id, Method method)

--- a/HitBtc/HitBtcCategories/RestAccount.cs
+++ b/HitBtc/HitBtcCategories/RestAccount.cs
@@ -1,164 +1,112 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Hitbtc.HitBtcModel;
 using RestSharp;
 
 namespace Hitbtc.HitBtcCategories
 {
+    /// <summary>Wallet operations for HitBTC API v3.</summary>
     public class RestAccount
     {
-
-        private readonly HitBtcRestApi _hitBtcRestApi;
-
-        public RestAccount(HitBtcRestApi hitBtcRestApi)
-        {
-            _hitBtcRestApi = hitBtcRestApi;
-        }
-
+        private readonly HitBtcRestApi _api;
+        public RestAccount(HitBtcRestApi api) { _api = api; }
 
         public async Task<List<Balance>> GetBalance()
         {
-            var request = new RestRequest("/api/2/account/balance");
-            return await _hitBtcRestApi.Execute(request);
+            return await _api.Execute(new RestRequest("/api/3/wallet/balance"));
         }
 
-        /// <summary>
-        /// Get current address
-        /// </summary>
-        /// <param name="currency"></param>
-        /// <returns></returns>
         public async Task<AddressModel> GetAddress(string currency)
         {
-            var request = new RestRequest("/api/2/account/crypto/address/{currency}");
-            request.AddParameter("currency", currency, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request);
+            var request = new RestRequest("/api/3/wallet/crypto/address");
+            request.AddQueryParameter("currency", currency);
+            var response = await _api.Execute(request);
+            var addresses = Utilities.ConvertListFromJson<AddressModel>(response);
+            return addresses.FirstOrDefault();
         }
 
-        /// <summary>
-        /// Create new address
-        /// </summary>
-        /// <param name="currency"></param>
-        /// <returns></returns>
         public async Task<AddressModel> PostAddress(string currency)
         {
-            var request = new RestRequest("/api/2/account/crypto/address/{currency}", Method.Post);
-            request.AddParameter("currency", currency, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request);
+            var request = new RestRequest("/api/3/wallet/crypto/address", Method.Post);
+            request.AddParameter("currency", currency);
+            return await _api.Execute(request);
         }
 
-        /// <summary>
-        /// Withdraw crypro
-        /// </summary>
-        /// <param name="currency">Currency</param>
-        /// <param name="amount">The amount that will be sent to the specified address</param>
-        /// <param name="address"></param>
-        /// <param name="paymentId">Optional parameter</param>
-        /// <param name="networkFee">Optional parameter. Too low and too high commission value will be rounded to valid values.</param>
-        /// <param name="includeFee">Default false. If set true then total will be spent the specified amount, fee and networkFee will be deducted from the amount</param>
-        /// <param name="autoCommit">Default true. If set false then you should commit or rollback transaction in an hour. Used in two phase commit schema.</param>
-        /// <returns>Unique identifier for Transaction as assigned by exchange</returns>
-        public async Task<IdObject> PostWithraw(string currency, int amount, string address, string paymentId = null,
-            string networkFee = null, bool includeFee = false, bool autoCommit = true)
+        public Task<IdObject> PostWithraw(string currency, int amount, string address,
+            string paymentId = null, string networkFee = null, bool includeFee = false,
+            bool autoCommit = true)
         {
-            var request = new RestRequest("/api/2/account/crypto/withdraw", Method.Post);
-            if (!string.IsNullOrEmpty(currency))
-                request.AddParameter("currency", currency);
-            if (amount > 0)
-                request.AddParameter("amount", amount);
-            if (!string.IsNullOrEmpty(address))
-                request.AddParameter("address", address);
-            if (!string.IsNullOrEmpty(paymentId))
-                request.AddParameter("paymentId", paymentId);
-            if (!string.IsNullOrEmpty(networkFee))
-                request.AddParameter("networkFee", networkFee);
-            request.AddParameter("includeFee", includeFee);
-            request.AddParameter("autoCommit", autoCommit);
-            return await _hitBtcRestApi.Execute(request);
+            return PostWithdraw(currency, amount.ToString(CultureInfo.InvariantCulture), address,
+                paymentId, null, includeFee, autoCommit);
         }
 
-        /// <summary>
-        /// Commit withdraw crypro
-        /// </summary>
-        /// <param name="withrawId">Unique identifier for Transaction as assigned by exchange</param>
-        /// <returns></returns>
+        /// <summary>Creates a v3 crypto withdrawal. The amount is a decimal string.</summary>
+        public async Task<IdObject> PostWithdraw(string currency, string amount, string address,
+            string paymentId = null, string networkCode = null, bool includeFee = false,
+            bool autoCommit = true)
+        {
+            var request = new RestRequest("/api/3/wallet/crypto/withdraw", Method.Post);
+            request.AddParameter("currency", currency);
+            request.AddParameter("amount", amount);
+            request.AddParameter("address", address);
+            AddOptional(request, "payment_id", paymentId);
+            AddOptional(request, "network_code", networkCode);
+            request.AddParameter("include_fee", includeFee.ToString().ToLowerInvariant());
+            request.AddParameter("auto_commit", autoCommit.ToString().ToLowerInvariant());
+            return await _api.Execute(request);
+        }
+
         public async Task<WithdrawConfirm> PutWithraw(string withrawId)
         {
-            var request = new RestRequest("/api/2/account/crypto/withdraw/{id}", Method.Put);
-            request.AddParameter("id", withrawId, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request);
+            return await _api.Execute(WithdrawalRequest(withrawId, Method.Put));
         }
 
-        /// <summary>
-        /// Rollback withdraw crypro
-        /// </summary>
-        /// <param name="withrawId">Unique identifier for Transaction as assigned by exchange</param>
-        /// <returns></returns>
         public async Task<WithdrawConfirm> DeleteWithraw(string withrawId)
         {
-            var request = new RestRequest("/api/2/account/crypto/withdraw/{id}", Method.Delete);
-            request.AddParameter("id", withrawId, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request);
+            return await _api.Execute(WithdrawalRequest(withrawId, Method.Delete));
         }
 
-        /// <summary>
-        /// Transfer money between trading and account
-        /// </summary>
-        /// <param name="currency"></param>
-        /// <param name="amount"></param>
-        /// <param name="type"></param>
-        /// <returns></returns>
         public async Task<IdObject> PostTransfer(string currency, int amount,
             PublicEnum.EnTransferType type = PublicEnum.EnTransferType.bankToExchange)
         {
-            var request = new RestRequest("/api/2/account/transfer", Method.Post);
-            if (!string.IsNullOrEmpty(currency))
-                request.AddParameter("currency", currency);
-            if (amount > 0)
-                request.AddParameter("amount", amount);
-            request.AddParameter("type", type.ToString());
-            return await _hitBtcRestApi.Execute(request);
+            var request = new RestRequest("/api/3/wallet/transfer", Method.Post);
+            request.AddParameter("currency", currency);
+            request.AddParameter("amount", amount.ToString(CultureInfo.InvariantCulture));
+            request.AddParameter("source", type == PublicEnum.EnTransferType.bankToExchange ? "wallet" : "spot");
+            request.AddParameter("destination", type == PublicEnum.EnTransferType.bankToExchange ? "spot" : "wallet");
+            var response = await _api.Execute(request);
+            var ids = Utilities.ConvertListFromJson<string>(response);
+            return new IdObject { Id = ids.FirstOrDefault() };
         }
 
-        /// <summary>
-        /// Get account transactions
-        /// </summary>
-        /// <returns></returns>
         public async Task<List<Transaction>> GetTransaction()
         {
-            return await _hitBtcRestApi.Execute(new RestRequest("/api/2/account/transactions"));
+            return await _api.Execute(new RestRequest("/api/3/wallet/transactions"));
         }
 
-        /// <summary>
-        ///  get transaction by transaction id
-        ///  Requires the "Payment information" API key permission.
-        /// </summary>
-        /// <param name="transactionId"></param>
-        /// <param name="currency"></param>
-        /// <param name="from"></param>
-        /// <param name="till"></param>
-        /// <param name="offset"></param>
-        /// <param name="limit"></param>
-        /// <param name="sort"></param>
-        /// <param name="by"></param>
-        /// <returns></returns>
-        public async Task<List<Transaction>> GetTransaction(string transactionId, string currency, string from, string till, int offset, int limit = 100,
-            PublicEnum.EnSort sort = PublicEnum.EnSort.Desc, PublicEnum.EnBy by = PublicEnum.EnBy.timestamp)
+        public async Task<List<Transaction>> GetTransaction(string transactionId, string currency,
+            string from, string till, int offset, int limit = 100,
+            PublicEnum.EnSort sort = PublicEnum.EnSort.Desc,
+            PublicEnum.EnBy by = PublicEnum.EnBy.timestamp)
         {
-            var request = new RestRequest("/api/2/account/transactions/{id}", Method.Get);
+            var request = new RestRequest("/api/3/wallet/transactions/{id}");
             request.AddParameter("id", transactionId, ParameterType.UrlSegment);
-            if (!string.IsNullOrEmpty(currency))
-                request.AddQueryParameter("currency", currency);
-            request.AddQueryParameter("sort", sort.ToString());
-            request.AddQueryParameter("by", by.ToString());
-            if (!string.IsNullOrEmpty(from))
-                request.AddQueryParameter("from", from);
-            if (!string.IsNullOrEmpty(till))
-                request.AddQueryParameter("till", till);
-            if (limit > 0)
-                request.AddQueryParameter("limit", limit.ToString());
-            if (offset > 0)
-                request.AddQueryParameter("offset", offset.ToString());
-            return await _hitBtcRestApi.Execute(request);
+            Transaction transaction = await _api.Execute(request);
+            return new List<Transaction> { transaction };
+        }
+
+        private static RestRequest WithdrawalRequest(string id, Method method)
+        {
+            var request = new RestRequest("/api/3/wallet/crypto/withdraw/{id}", method);
+            request.AddParameter("id", id, ParameterType.UrlSegment);
+            return request;
+        }
+
+        private static void AddOptional(RestRequest request, string name, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value)) request.AddParameter(name, value);
         }
     }
 }

--- a/HitBtc/HitBtcCategories/RestPublicData.cs
+++ b/HitBtc/HitBtcCategories/RestPublicData.cs
@@ -1,79 +1,84 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Hitbtc.HitBtcModel;
 using RestSharp;
 
 namespace Hitbtc.HitBtcCategories
 {
-    /// <summary>
-    /// Market data RESTful API
-    /// </summary>
+    /// <summary>Public market-data operations for HitBTC API v3.</summary>
     public class RestPublicData
     {
-        private readonly HitBtcRestApi _hitBtcRestApi;
-
-        public RestPublicData(HitBtcRestApi hitBtcRestApi)
-        {
-            _hitBtcRestApi = hitBtcRestApi;
-        }
+        private readonly HitBtcRestApi _api;
+        public RestPublicData(HitBtcRestApi api) { _api = api; }
 
         public async Task<List<Symbol>> GetSymbol()
         {
-            return await _hitBtcRestApi.Execute(new RestRequest("/api/2/public/symbol"), false);
+            var response = await _api.Execute(new RestRequest("/api/3/public/symbol"), false);
+            var values = Utilities.ConvertDictionaryFromJson<Symbol>(response);
+            foreach (var item in values) item.Value.Id = item.Key;
+            return values.Values.ToList();
         }
 
         public async Task<Symbol> GetSymbol(string symbolName)
         {
-            var request = new RestRequest("/api/2/public/symbol/{symbol}");
+            var request = new RestRequest("/api/3/public/symbol/{symbol}");
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request, false);
+            Symbol value = await _api.Execute(request, false);
+            value.Id = symbolName;
+            return value;
         }
-
 
         public async Task<List<Currency>> GetCurrency()
         {
-            return await _hitBtcRestApi.Execute(new RestRequest("/api/2/public/currency"), false);
+            var response = await _api.Execute(new RestRequest("/api/3/public/currency"), false);
+            var values = Utilities.ConvertDictionaryFromJson<Currency>(response);
+            foreach (var item in values) item.Value.Id = item.Key;
+            return values.Values.ToList();
         }
-
 
         public async Task<Currency> GetCurrency(string currencyName)
         {
-            var request = new RestRequest("/api/2/public/currency/{currency}");
+            var request = new RestRequest("/api/3/public/currency/{currency}");
             request.AddParameter("currency", currencyName, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request, false);
+            Currency value = await _api.Execute(request, false);
+            value.Id = currencyName;
+            return value;
         }
 
         public async Task<List<Ticker>> GetTicker()
         {
-            return await _hitBtcRestApi.Execute(new RestRequest("/api/2/public/ticker"), false);
+            var response = await _api.Execute(new RestRequest("/api/3/public/ticker"), false);
+            var values = Utilities.ConvertTickerDictionaryFromJson(response);
+            foreach (var item in values) item.Value.Symbol = item.Key;
+            return values.Values.ToList();
         }
 
         public async Task<Ticker> GetTicker(string symbolName, string period = null, int limit = 0)
         {
-            var request = new RestRequest { Resource = "api/2/public/ticker/{symbol}" };
+            var request = new RestRequest("/api/3/public/ticker/{symbol}");
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            if (limit > 0)
-                request.AddQueryParameter("limit", limit.ToString());
-            if (!string.IsNullOrEmpty(period))
-                request.AddQueryParameter("period", period);
-            return await _hitBtcRestApi.Execute(request, false);
+            Ticker value = await _api.Execute(request, false);
+            value.Symbol = symbolName;
+            return value;
         }
 
         public async Task<Orderbook> GetOrderbook(string symbolName, int limit = 0)
         {
-            var request = new RestRequest("api/2/public/orderbook/{symbol}");
+            var request = new RestRequest("/api/3/public/orderbook/{symbol}");
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            request.AddQueryParameter("limit", limit.ToString());
-            return await _hitBtcRestApi.Execute(request, false);
+            if (limit > 0) request.AddQueryParameter("depth", limit.ToString());
+            return await _api.Execute(request, false);
         }
 
-        public async Task<List<Candle>> GetCandles(string symbolName, PublicEnum.EnPeriod enPeriod = PublicEnum.EnPeriod.M30)
+        public async Task<List<Candle>> GetCandles(string symbolName,
+            PublicEnum.EnPeriod enPeriod = PublicEnum.EnPeriod.M30)
         {
-            var period = enPeriod.ToString() == "Month" ? "1M" : enPeriod.ToString();
-            var request = new RestRequest("api/2/public/candles/{symbol}");
+            var period = enPeriod == PublicEnum.EnPeriod.Month ? "1M" : enPeriod.ToString();
+            var request = new RestRequest("/api/3/public/candles/{symbol}");
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
             request.AddQueryParameter("period", period);
-            return await _hitBtcRestApi.Execute(request, false);
+            return await _api.Execute(request, false);
         }
     }
 }

--- a/HitBtc/HitBtcCategories/RestTrading.cs
+++ b/HitBtc/HitBtcCategories/RestTrading.cs
@@ -1,70 +1,35 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hitbtc.HitBtcModel;
 using RestSharp;
 
 namespace Hitbtc.HitBtcCategories
 {
-    /// <summary>
-    /// Trading RESTful API
-    /// </summary>
+    /// <summary>Spot trading operations for HitBTC API v3.</summary>
     public class RestTrading
     {
-        private readonly HitBtcRestApi _hitBtcRestApi;
+        private readonly HitBtcRestApi _api;
+        public RestTrading(HitBtcRestApi api) { _api = api; }
 
-        public RestTrading(HitBtcRestApi hitBtcApi)
-        {
-            _hitBtcRestApi = hitBtcApi;
-        }
-
-        /// <summary>
-        /// Get trading balance
-        /// </summary>
-        /// <returns></returns>
         public async Task<List<Balance>> GetBalance()
         {
-            return await _hitBtcRestApi.Execute(new RestRequest("/api/2/trading/balance", Method.Get));
+            return await _api.Execute(new RestRequest("/api/3/spot/balance", Method.Get));
         }
 
-        /// <summary>
-        /// Get trading fee rate
-        /// </summary>
-        /// <param name="symbolName"></param>
-        /// <returns></returns>
         public async Task<Fee> GetFee(string symbolName)
         {
-            var request = new RestRequest("/api/2/trading/fee/{symbol}", Method.Get);
+            var request = new RestRequest("/api/3/spot/fee/{symbol}", Method.Get);
             request.AddParameter("symbol", symbolName, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request);
+            return await _api.Execute(request);
         }
 
-        /// <summary>
-        /// List your current open orders
-        /// </summary>
-        /// <param name="symbolName"></param>
-        /// <returns></returns>
-        //public async Task<List<Order>> GetOrders(string symbolName)
-        public async Task<List<Order>> GetOrders(string symbolName)
+        public async Task<List<Order>> GetOrders(string symbolName = null)
         {
-            var request = new RestRequest("/api/2/order", Method.Get);
-            request.AddQueryParameter("symbol", symbolName);
-            return await _hitBtcRestApi.Execute(request);
+            var request = new RestRequest("/api/3/spot/order", Method.Get);
+            AddOptionalQuery(request, "symbol", symbolName);
+            return await _api.Execute(request);
         }
 
-        /// <summary>
-        /// Create new order
-        /// </summary>
-        /// <param name="symbolName"> Trading symbol</param>
-        /// <param name="quantity"> Order quantity</param>
-        /// <param name="side">sell buy</param>
-        /// <param name="type"></param>
-        /// <param name="timeInForce">Time in force is a special instruction used when placing a trade to indicate how long an order will remain active before it is executed or expires </param>
-        /// <param name="price"></param>
-        /// <param name="stopPrice"></param>
-        /// <param name="expireTime"></param>
-        /// <param name="clientOrderId">Unique identifier for Order as assigned by trader. Uniqueness must be guaranteed within a single trading day, including all active orders.</param>
-        /// <param name="strictValidate"></param>
-        /// <returns></returns>
         public async Task<Order> PostOrders(string symbolName, string quantity,
             PublicEnum.EnTradingSide side = PublicEnum.EnTradingSide.buy,
             PublicEnum.EnTradingType type = PublicEnum.EnTradingType.limit,
@@ -72,119 +37,95 @@ namespace Hitbtc.HitBtcCategories
             string price = null, string stopPrice = null, string expireTime = null,
             string clientOrderId = null, bool strictValidate = false)
         {
-            var request = new RestRequest("/api/2/order", Method.Post);
-            request.AddParameter("symbol", symbolName);
-            request.AddParameter("quantity", quantity);
-            request.AddParameter("side", side.ToString());
-            request.AddParameter("type", type.ToString());
-            request.AddParameter("timeInForce", timeInForce.ToString());
-            if (!string.IsNullOrEmpty(price))
-                request.AddParameter("price", price);
-            if (!string.IsNullOrEmpty(stopPrice))
-                request.AddParameter("stopPrice", stopPrice);
-            if (!string.IsNullOrEmpty(expireTime))
-                request.AddParameter("expireTime", expireTime);
-            if (!string.IsNullOrEmpty(clientOrderId))
-                request.AddParameter("clientOrderId", clientOrderId);
-            request.AddParameter("strictValidate", strictValidate);
-            return await _hitBtcRestApi.Execute(request);
+            var request = CreateOrderRequest("/api/3/spot/order", Method.Post, symbolName, quantity,
+                side, type, timeInForce, price, stopPrice, expireTime, strictValidate);
+            AddOptionalBody(request, "client_order_id", clientOrderId);
+            return await _api.Execute(request);
         }
 
-        /// <summary>
-        /// Cancel all open orders
-        /// </summary>
-        /// <param name="symbolName"></param>
-        /// <returns></returns>
-        public async Task<List<Order>> DeleteOrders(string symbolName)
+        public async Task<List<Order>> DeleteOrders(string symbolName = null)
         {
-            var request = new RestRequest("/api/2/order", Method.Delete);
-            request.AddQueryParameter("symbol", symbolName);
-            return await _hitBtcRestApi.Execute(request);
+            var request = new RestRequest("/api/3/spot/order", Method.Delete);
+            AddOptionalQuery(request, "symbol", symbolName);
+            return await _api.Execute(request);
         }
 
-
-        /// <summary>
-        /// Get a single order by clientOrderId
-        /// </summary>
-        /// <param name="clientOrderId"></param>
-        /// <param name="wait">Optional parameter. Time in milliseconds. Max 60000. </param>
-        /// <returns></returns>
         public async Task<Order> GetOrder(string clientOrderId, int wait = 0)
         {
-            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Get);
-            request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
-            if (wait > 0)
-                request.AddQueryParameter("wait", wait.ToString());
-            return await _hitBtcRestApi.Execute(request);
+            return await _api.Execute(OrderRequest(clientOrderId, Method.Get));
         }
 
-        /// <summary>
-        /// Create new order
-        /// </summary>
-        /// <param name="symbolName"> Trading symbol</param>
-        /// <param name="quantity"> Order quantity</param>
-        /// <param name="side">sell buy</param>
-        /// <param name="type"></param>
-        /// <param name="timeInForce">Time in force is a special instruction used when placing a trade to indicate how long an order will remain active before it is executed or expires </param>
-        /// <param name="price"></param>
-        /// <param name="stopPrice"></param>
-        /// <param name="expireTime"></param>
-        /// <param name="clientOrderId">Unique identifier for Order as assigned by trader. Uniqueness must be guaranteed within a single trading day, including all active orders.</param>
-        /// <param name="strictValidate"></param>
-        /// <returns></returns>
-        public async Task<Order> PutOrder(string clientOrderId ,string symbolName, string quantity,
+        public async Task<Order> PutOrder(string clientOrderId, string symbolName, string quantity,
             PublicEnum.EnTradingSide side = PublicEnum.EnTradingSide.buy,
             PublicEnum.EnTradingType type = PublicEnum.EnTradingType.limit,
             PublicEnum.EnTradingTimeInForce timeInForce = PublicEnum.EnTradingTimeInForce.GTC,
-            string price = null, string stopPrice = null, string expireTime = null, bool strictValidate = false)
+            string price = null, string stopPrice = null, string expireTime = null,
+            bool strictValidate = false)
         {
-            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Put);
+            var request = CreateOrderRequest("/api/3/spot/order/{clientOrderId}", Method.Put, symbolName,
+                quantity, side, type, timeInForce, price, stopPrice, expireTime, strictValidate);
             request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
-            request.AddParameter("symbol", symbolName);
-            request.AddParameter("quantity", quantity);
-            request.AddParameter("side", side.ToString());
-            request.AddParameter("type", type.ToString());
-            request.AddParameter("timeInForce", timeInForce.ToString());
-            if (!string.IsNullOrEmpty(price))
-                request.AddParameter("price", price);
-            if (!string.IsNullOrEmpty(stopPrice))
-                request.AddParameter("stopPrice", stopPrice);
-            if (!string.IsNullOrEmpty(expireTime))
-                request.AddParameter("expireTime", expireTime);
-            request.AddParameter("strictValidate", strictValidate);
-            return await _hitBtcRestApi.Execute(request);
+            return await _api.Execute(request);
         }
 
-        /// <summary>
-        /// Cancel all open orders
-        /// </summary>
-        /// <param name="clientOrderId"></param>
-        /// <returns></returns>
         public async Task<Order> DeleteOrder(string clientOrderId)
         {
-            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Delete);
-            request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request);
+            return await _api.Execute(OrderRequest(clientOrderId, Method.Delete));
         }
 
-        /// <summary>
-        /// Cancel Replace order
-        /// </summary>
-        /// <param name="clientOrderId"></param>
-        /// <param name="quantity"></param>
-        /// <param name="requestClientId"></param>
-        /// <param name="price"></param>
-        /// <returns></returns>
-        public async Task<Order> PatchOrder(string clientOrderId, string quantity, string requestClientId,
-            string price = null)
+        public async Task<Order> PatchOrder(string clientOrderId, string quantity,
+            string requestClientId, string price = null)
         {
-            var request = new RestRequest("/api/2/order/{clientOrderId}", Method.Patch);
-            request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
+            var request = OrderRequest(clientOrderId, Method.Patch);
+            AddOptionalBody(request, "quantity", quantity);
+            AddOptionalBody(request, "new_client_order_id", requestClientId);
+            AddOptionalBody(request, "price", price);
+            return await _api.Execute(request);
+        }
+
+        private static RestRequest CreateOrderRequest(string resource, Method method, string symbol,
+            string quantity, PublicEnum.EnTradingSide side, PublicEnum.EnTradingType type,
+            PublicEnum.EnTradingTimeInForce timeInForce, string price, string stopPrice,
+            string expireTime, bool strictValidate)
+        {
+            var request = new RestRequest(resource, method);
+            request.AddParameter("symbol", symbol);
             request.AddParameter("quantity", quantity);
-            request.AddParameter("requestClientId", requestClientId);
-            if (!string.IsNullOrEmpty(price))
-                request.AddParameter("price", price);
-            return await _hitBtcRestApi.Execute(request);
+            request.AddParameter("side", side.ToString());
+            request.AddParameter("type", ToApiValue(type));
+            request.AddParameter("time_in_force", timeInForce.ToString());
+            AddOptionalBody(request, "price", price);
+            AddOptionalBody(request, "stop_price", stopPrice);
+            AddOptionalBody(request, "expire_time", expireTime);
+            request.AddParameter("strict_validate", strictValidate.ToString().ToLowerInvariant());
+            return request;
+        }
+
+        private static RestRequest OrderRequest(string clientOrderId, Method method)
+        {
+            var request = new RestRequest("/api/3/spot/order/{clientOrderId}", method);
+            request.AddParameter("clientOrderId", clientOrderId, ParameterType.UrlSegment);
+            return request;
+        }
+
+        private static string ToApiValue(PublicEnum.EnTradingType type)
+        {
+            switch (type)
+            {
+                case PublicEnum.EnTradingType.stopLimit: return "stop_limit";
+                case PublicEnum.EnTradingType.stopMarket: return "stop_market";
+                default: return type.ToString();
+            }
+        }
+
+        private static void AddOptionalBody(RestRequest request, string name, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value)) request.AddParameter(name, value);
+        }
+
+        private static void AddOptionalQuery(RestRequest request, string name, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value)) request.AddQueryParameter(name, value);
         }
     }
 }

--- a/HitBtc/HitBtcCategories/RestTradingHistory.cs
+++ b/HitBtc/HitBtcCategories/RestTradingHistory.cs
@@ -1,87 +1,59 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hitbtc.HitBtcModel;
 using RestSharp;
 
 namespace Hitbtc.HitBtcCategories
 {
+    /// <summary>Spot order and trade history for HitBTC API v3.</summary>
     public class RestTradingHistory
     {
-        private readonly HitBtcRestApi _hitBtcRestApi;
+        private readonly HitBtcRestApi _api;
+        public RestTradingHistory(HitBtcRestApi api) { _api = api; }
 
-        public RestTradingHistory(HitBtcRestApi hitBtcRestApi)
+        public async Task<List<TradeHistory>> GetTraders(string symoblName, string from,
+            string till, int offset, int limit = 100,
+            PublicEnum.EnSort sort = PublicEnum.EnSort.Desc,
+            PublicEnum.EnBy by = PublicEnum.EnBy.timestamp)
         {
-            _hitBtcRestApi = hitBtcRestApi;
+            var request = HistoryRequest("/api/3/spot/history/trade", symoblName, from, till,
+                offset, limit, sort, by);
+            return await _api.Execute(request);
         }
 
-        /// <summary>
-        /// Get historical trades
-        /// </summary>
-        /// <param name="symoblName"></param>
-        /// <param name="sort">Sort direction</param>
-        /// <param name="by">Filter field</param>
-        /// <param name="from">If filter by timestamp, then datetime in iso format or timestamp in millisecond otherwise trade id</param>
-        /// <param name="till">If filter by timestamp, then datetime in iso format or timestamp in millisecond otherwise trade id</param>
-        /// <param name="offset"></param>
-        /// <param name="limit"></param>
-        /// <returns></returns>
-        public async Task<List<TradeHistory>> GetTraders(string symoblName, string from, string till, int offset, int limit = 100,
-            PublicEnum.EnSort sort = PublicEnum.EnSort.Desc, PublicEnum.EnBy by = PublicEnum.EnBy.timestamp)
+        public async Task<List<Order>> GetOrder(string symoblName, string clientOrderId,
+            string from, string till, int offset, int limit = 100)
         {
-            var request = new RestRequest("/api/2/history/trades");
-            if (!string.IsNullOrEmpty(symoblName))
-                request.AddQueryParameter("symbol", symoblName);
-
-            request.AddQueryParameter("sort", sort.ToString());
-
-            request.AddQueryParameter("by", by.ToString());
-
-            if (!string.IsNullOrEmpty(from))
-                request.AddQueryParameter("from", from);
-            if (!string.IsNullOrEmpty(till))
-                request.AddQueryParameter("till", till);
-            if (offset > 0)
-                request.AddQueryParameter("offset", offset.ToString());
-            if (limit > 0)
-                request.AddQueryParameter("limit", limit.ToString());
-
-            return await _hitBtcRestApi.Execute(request);
+            var request = HistoryRequest("/api/3/spot/history/order", symoblName, from, till,
+                offset, limit, PublicEnum.EnSort.Desc, PublicEnum.EnBy.timestamp);
+            AddOptional(request, "client_order_id", clientOrderId);
+            return await _api.Execute(request);
         }
 
-        /// <summary>
-        /// Get historical orders
-        /// </summary>
-        /// <returns></returns>
-        public async Task<List<Order>> GetOrder(string symoblName, string clientOrderId, string from, string till,
-            int offset, int limit = 100)
-        {
-
-            var request = new RestRequest("/api/2/history/order");
-            if (!string.IsNullOrEmpty(symoblName))
-                request.AddQueryParameter("symbol", symoblName);
-            if (!string.IsNullOrEmpty(clientOrderId))
-                request.AddQueryParameter("clientOrderId", clientOrderId);
-            if (!string.IsNullOrEmpty(from))
-                request.AddQueryParameter("from", from);
-            if (!string.IsNullOrEmpty(till))
-                request.AddQueryParameter("till", till);
-            if (offset > 0)
-                request.AddQueryParameter("offset", offset.ToString());
-            if (limit > 0)
-                request.AddQueryParameter("limit", limit.ToString());
-
-            return await _hitBtcRestApi.Execute(request);
-        }
-
-        /// <summary>
-        /// Get historical trades by specified order
-        /// </summary>
-        /// <returns></returns>
         public async Task<List<TradeHistory>> GetTradersByOrder(string orderId)
         {
-            var request = new RestRequest("/api/2/history/order/{orderId}/trades");
-            request.AddParameter("orderId", orderId, ParameterType.UrlSegment);
-            return await _hitBtcRestApi.Execute(request);
+            var request = new RestRequest("/api/3/spot/history/trade");
+            request.AddQueryParameter("order_id", orderId);
+            return await _api.Execute(request);
+        }
+
+        private static RestRequest HistoryRequest(string resource, string symbol, string from,
+            string till, int offset, int limit, PublicEnum.EnSort sort, PublicEnum.EnBy by)
+        {
+            var request = new RestRequest(resource);
+            AddOptional(request, "symbol", symbol);
+            AddOptional(request, "from", from);
+            AddOptional(request, "till", till);
+            request.AddQueryParameter("sort", sort.ToString().ToUpperInvariant());
+            request.AddQueryParameter("by", by.ToString());
+            if (offset > 0) request.AddQueryParameter("offset", offset.ToString());
+            if (limit > 0) request.AddQueryParameter("limit", limit.ToString());
+            return request;
+        }
+
+        private static void AddOptional(RestRequest request, string name, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value)) request.AddQueryParameter(name, value);
         }
     }
 }

--- a/HitBtc/HitBtcCategories/SocketMarketData.cs
+++ b/HitBtc/HitBtcCategories/SocketMarketData.cs
@@ -1,346 +1,98 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+using System;
 using System.Threading.Tasks;
 using Hitbtc.HitBtcModel;
+using Newtonsoft.Json.Linq;
 
 namespace Hitbtc.HitBtcCategories
 {
+    /// <summary>Public streaming subscriptions for HitBTC API v3.</summary>
     public class SocketMarketData
     {
-        private readonly HitBtcSocketApi _hitBtcSocketApi;
+        private readonly HitBtcSocketApi _api;
+        public SocketMarketData(HitBtcSocketApi api) { _api = api; }
 
-        public SocketMarketData(HitBtcSocketApi hitBtcSocketApi)
+        [Obsolete("API v3 exposes currencies through RestApi.PublicData.")]
+        public Task<SocketCurrencies> GetCurrencies(int id = 123) { return Unsupported<SocketCurrencies>(); }
+
+        [Obsolete("API v3 exposes currencies through RestApi.PublicData.")]
+        public Task<SocketCurrency> GetCurrency(string currencyName, int id = 123) { return Unsupported<SocketCurrency>(); }
+
+        [Obsolete("API v3 exposes symbols through RestApi.PublicData.")]
+        public Task<SocketSymbols> GetSymbols(int id = 123) { return Unsupported<SocketSymbols>(); }
+
+        [Obsolete("API v3 exposes symbols through RestApi.PublicData.")]
+        public Task<SocketSymbol> GetSymbol(string symbol, int id = 123) { return Unsupported<SocketSymbol>(); }
+
+        [Obsolete("API v3 exposes historical trades through RestApi.TradingHistory.")]
+        public Task<SocketTrades> GetTrades(string symoblName, string from, string till, int offset,
+            int id = 123, int limit = 100, PublicEnum.EnSort sort = PublicEnum.EnSort.Desc,
+            PublicEnum.EnBy by = PublicEnum.EnBy.timestamp) { return Unsupported<SocketTrades>(); }
+
+        public Task<SocketSubscribe> SubscribeTicker(string symbol, int id = 123)
         {
-            _hitBtcSocketApi = hitBtcSocketApi;
+            return Subscription("subscribe", "ticker/1s", symbol, id);
         }
 
-        public async Task<SocketCurrencies> GetCurrencies(int id = 123)
+        public Task<SocketSubscribe> UnsubscribeTicker(string symbol, int id = 123)
         {
-            var request = string.Format("{{ \"method\": \"getCurrencies\", \"params\": {{  }}, \"id\": {0} }}", id);
-            return await _hitBtcSocketApi.Execute(request, false);
+            return Subscription("unsubscribe", "ticker/1s", symbol, id);
         }
 
-        public async Task<SocketCurrency> GetCurrency(string currencyName, int id = 123)
+        public Task<SocketSubscribe> SubscribeOrderbook(string symbol, int id = 123)
         {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"getCurrency\", \"params\": {{ \"currency\": \"{0}\" }}, \"id\": {1} }}",
-                    currencyName, id);
-            return await _hitBtcSocketApi.Execute(request, false);
+            return Subscription("subscribe", "orderbook/full", symbol, id);
         }
 
-        public async Task<SocketSymbols> GetSymbols(int id = 123)
+        public Task<SocketSubscribe> UnsubscribeOrderbook(string symbol, int id = 123)
         {
-            var request = string.Format("{{ \"method\": \"getSymbols\", \"params\": {{  }}, \"id\": {0} }}", id);
-            return await _hitBtcSocketApi.Execute(request, false);
+            return Subscription("unsubscribe", "orderbook/full", symbol, id);
         }
 
-        public async Task<SocketSymbol> GetSymbol(string symbol, int id = 123)
+        public Task<SocketSubscribe> SubscribeTrades(string symbol, int id = 123)
         {
-            var request =
-                string.Format("{{ \"method\": \"getSymbol\", \"params\": {{ \"symbol\": \"{0}\" }}, \"id\": {1} }}",
-                    symbol, id);
-            return await _hitBtcSocketApi.Execute(request, false);
+            return Subscription("subscribe", "trades", symbol, id);
         }
 
-        public async Task<SocketSubscribe> SubscribeTicker(string symbol, int id = 123)
+        public Task<SocketSubscribe> UnsubscribeTrades(string symbol, int id = 123)
         {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"subscribeTicker\", \"params\": {{ \"symbol\": \"{0}\" }}, \"id\": {1} }}",
-                    symbol, id);
-            return await _hitBtcSocketApi.Execute(request, false);
+            return Subscription("unsubscribe", "trades", symbol, id);
         }
 
-        public async Task<SocketSubscribe> UnsubscribeTicker(string symbol, int id = 123)
+        public Task<SocketSubscribe> SubscribeCandles(string symbol,
+            PublicEnum.EnPeriod enPeriod = PublicEnum.EnPeriod.M30, int id = 123)
         {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"unsubscribeTicker\", \"params\": {{ \"symbol\": \"{0}\" }}, \"id\": {1} }}",
-                    symbol, id);
-            return await _hitBtcSocketApi.Execute(request, false);
+            return Subscription("subscribe", "candles/" + Period(enPeriod), symbol, id);
         }
 
-        public async Task<SocketSubscribe> SubscribeOrderbook(string symbol, int id = 123)
+        public Task<SocketSubscribe> UnsubscribeCandles(string symbol,
+            PublicEnum.EnPeriod enPeriod = PublicEnum.EnPeriod.M30, int id = 123)
         {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"subscribeOrderbook\", \"params\": {{ \"symbol\": \"{0}\" }}, \"id\": {1} }}",
-                    symbol, id);
-            return await _hitBtcSocketApi.Execute(request, false);
+            return Subscription("unsubscribe", "candles/" + Period(enPeriod), symbol, id);
         }
 
-        public async Task<SocketSubscribe> UnsubscribeOrderbook(string symbol, int id = 123)
+        private async Task<SocketSubscribe> Subscription(string method, string channel,
+            string symbol, int id)
         {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"unsubscribeOrderbook\", \"params\": {{ \"symbol\": \"{0}\" }}, \"id\": {1} }}",
-                    symbol, id);
-            return await _hitBtcSocketApi.Execute(request, false);
-        }
-
-        public async Task<SocketSubscribe> SubscribeTrades(string symbol, int id = 123)
-        {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"subscribeTrades\", \"params\": {{ \"symbol\": \"{0}\" }}, \"id\": {1} }}", symbol,
-                    id);
-            return await _hitBtcSocketApi.Execute(request, false);
-        }
-
-        public async Task<SocketSubscribe> UnsubscribeTrades(string symbol, int id = 123)
-        {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"unsubscribeTrades\", \"params\": {{ \"symbol\": \"{0}\" }}, \"id\": {1} }}",
-                    symbol, id);
-            return await _hitBtcSocketApi.Execute(request, false);
-        }
-
-        public async Task<SocketSubscribe> SubscribeCandles(string symbol, PublicEnum.EnPeriod enPeriod = PublicEnum.EnPeriod.M30, int id = 123)
-        {
-            var period = enPeriod.ToString() == "Month" ? "1M" : enPeriod.ToString();
-            var request =
-                string.Format(
-                    "{{ \"method\": \"subscribeCandles\", \"params\": {{ \"symbol\": \"{0}\" , \"period\": \"{1}\" }}, \"id\": {2} }}",
-                    symbol, period, id);
-            return await _hitBtcSocketApi.Execute(request, false);
-        }
-
-        public async Task<SocketSubscribe> UnsubscribeCandles(string symbol, PublicEnum.EnPeriod enPeriod = PublicEnum.EnPeriod.M30, int id = 123)
-        {
-            var period = enPeriod.ToString() == "Month" ? "1M" : enPeriod.ToString();
-            var request =
-                string.Format(
-                    "{{ \"method\": \"unsubscribeCandles\", \"params\": {{ \"symbol\": \"{0}\" , \"period\": \"{1}\"}}, \"id\": {2} }}",
-                    symbol, period, id);
-            return await _hitBtcSocketApi.Execute(request, false);
-        }
-
-        /// <summary>
-        /// Get historical trades
-        /// </summary>
-        /// <param name="symoblName"></param>
-        /// <param name="sort">Sort direction</param>
-        /// <param name="by">Filter field</param>
-        /// <param name="from">If filter by timestamp, then datetime in iso format or timestamp in millisecond otherwise trade id</param>
-        /// <param name="till">If filter by timestamp, then datetime in iso format or timestamp in millisecond otherwise trade id</param>
-        /// <param name="offset"></param>
-        /// <param name="id"></param>
-        /// <param name="limit"></param>
-        /// <returns></returns>
-        public async Task<SocketTrades> GetTrades(string symoblName, string from, string till, int offset, int id = 123,
-            int limit = 100,
-            PublicEnum.EnSort sort = PublicEnum.EnSort.Desc, PublicEnum.EnBy by = PublicEnum.EnBy.timestamp)
-        {
-
-            string[] paramterArray = new string[7];
-            if (!string.IsNullOrEmpty(symoblName))
-                paramterArray[0] = string.Format("\"symbol\": \"{0}\"", symoblName);
-            paramterArray[1] = string.Format("\"sort\": \"{0}\"", sort.ToString());
-            paramterArray[2] = string.Format("\"by\": \"{0}\"", by.ToString());
-            if (!string.IsNullOrEmpty(from))
-                paramterArray[3] = string.Format("\"from\": \"{0}\"", from);
-            if (!string.IsNullOrEmpty(till))
-                paramterArray[4] = string.Format("\"till\": \"{0}\"", till);
-            if (limit > 0)
-                paramterArray[5] = string.Format("\"limit\": \"{0}\"", limit.ToString());
-            if (offset > 0)
-                paramterArray[6] = string.Format("\"offset\": \"{0}\"", offset.ToString());
-            string parameters = string.Empty;
-
-            for (var index = 0; index < paramterArray.Length - 1; index++)
+            var request = new JObject
             {
-                if (!string.IsNullOrEmpty(paramterArray[index]))
-                    parameters += paramterArray[index] + " , ";
-            }
-
-            if (!string.IsNullOrEmpty(paramterArray[6]))
-                parameters += paramterArray[6];
-
-            var request =
-                string.Format("{{ \"method\": \"getTrades\", \"params\": {{ {0} }}, \"id\": {1} }}",
-                parameters, id);
-            return await _hitBtcSocketApi.Execute(request, false);
+                ["method"] = method,
+                ["ch"] = channel,
+                ["params"] = new JObject { ["symbols"] = new JArray(symbol) },
+                ["id"] = id
+            }.ToString(Newtonsoft.Json.Formatting.None);
+            return await _api.Execute(request, false);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="ask"></param>
-        /// <param name="bid"></param>
-        /// <param name="last"></param>
-        /// <param name="open"></param>
-        /// <param name="low"></param>
-        /// <param name="high"></param>
-        /// <param name="volume"></param>
-        /// <param name="volumeQuote"></param>
-        /// <param name="timestamp"></param>
-        /// <param name="symbol"></param>
-        public async void NotificationTicker(string ask, string bid, string last, string open, string low, string high,
-            string volume, string volumeQuote, string timestamp, string symbol)
+        private static string Period(PublicEnum.EnPeriod period)
         {
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"ticker\",\"params\":{{\"ask\":\"{0}\",\"bid\":\"{1}\",\"last\":\"{2}\",\"open\":\"{3}3\",\"low\":\"{4}\",\"high\":\"{5}\",\"volume\":\"{6}\",\"volumeQuote\":\"{7}\",\"timestamp\":\"{8}\",\"symbol\":\"{9}\"}}}}",
-                    ask, bid, last, open, low, high, volume, volumeQuote, timestamp, symbol);
-            await _hitBtcSocketApi.Execute(request);
+            return period == PublicEnum.EnPeriod.Month ? "1M" : period.ToString();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <param name="sequence"></param>
-        /// <param name="asks"></param>
-        /// <param name="bids"></param>
-        public async void NotificationSnapshotOrderbook(string symbol, string sequence, List<OrderBookParamter> asks,
-            List<OrderBookParamter> bids)
+        private static Task<T> Unsupported<T>()
         {
-            string askParamter = string.Empty;
-            string bidParamter = string.Empty;
-
-            askParamter = asks.Aggregate(askParamter,
-                (current, ask) =>
-                    current + string.Format(" {{\"price\":\"{0}\",\"size\":\"{1}\"}},", ask.Price, ask.Size));
-
-            askParamter = bids.Aggregate(askParamter,
-                (current, bid) =>
-                    current + string.Format(" {{\"price\":\"{0}\",\"size\":\"{1}\"}},", bid.Price, bid.Size));
-
-            askParamter = askParamter.TrimEnd(',');
-            bidParamter = bidParamter.TrimEnd(',');
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"snapshotOrderbook\",\"params\":{{\"ask\":[{0}],\"bid\":[{1}],\"symbol\":\"{2}\",\"sequence\":{3}}}}}",
-                    askParamter, bidParamter, symbol, sequence);
-            await _hitBtcSocketApi.Execute(request);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <param name="sequence"></param>
-        /// <param name="asks"></param>
-        /// <param name="bids"></param>
-        public async void NotificationUpdateOrderbook(string symbol, string sequence, List<OrderBookParamter> asks,
-            List<OrderBookParamter> bids)
-        {
-            string askParamter = string.Empty;
-            string bidParamter = string.Empty;
-
-            askParamter = asks.Aggregate(askParamter,
-                (current, ask) =>
-                    current + string.Format(" {{\"price\":\"{0}\",\"size\":\"{1}\"}},", ask.Price, ask.Size));
-
-            askParamter = bids.Aggregate(askParamter,
-                (current, bid) =>
-                    current + string.Format(" {{\"price\":\"{0}\",\"size\":\"{1}\"}},", bid.Price, bid.Size));
-
-            askParamter = askParamter.TrimEnd(',');
-            bidParamter = bidParamter.TrimEnd(',');
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"updateOrderbook\",\"params\":{{\"ask\":[{0}],\"bid\":[{1}],\"symbol\":\"{2}\",\"sequence\":{3}}}}}",
-                    askParamter, bidParamter, symbol, sequence);
-            await _hitBtcSocketApi.Execute(request);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <param name="data"></param>
-        public async void NotificationSnapshotTrades(string symbol, List<SocketTrade> data)
-        {
-            string dataParameters = data.Aggregate(string.Empty,
-                (current, parameter) =>
-                    current +
-                    string.Format(
-                        " {{\"id\":{0},\"price\":\"{1}\",\"quantity\":\"{2}\",\"side\":\"{3}\",\"timestamp\":\"{4}\"}},",
-                        parameter.Id, parameter.Price, parameter.Quantity, parameter.Side, parameter.Timestamp));
-
-            dataParameters = dataParameters.TrimEnd(',');
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"snapshotTrades\",\"params\":{{\"data\":[{0}],\"symbol\":\"{1}\"}}}}",
-                    dataParameters, symbol);
-            await _hitBtcSocketApi.Execute(request);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <param name="data"></param>
-        public async void NotificationUpdateTrades(string symbol, List<SocketTrade> data)
-        {
-
-            string dataParameters = data.Aggregate(string.Empty,
-                (current, parameter) =>
-                    current +
-                    string.Format(
-                        " {{\"id\":{0},\"price\":\"{1}\",\"quantity\":\"{2}\",\"side\":\"{3}\",\"timestamp\":\"{4}\"}},",
-                        parameter.Id, parameter.Price, parameter.Quantity, parameter.Side, parameter.Timestamp));
-
-            dataParameters = dataParameters.TrimEnd(',');
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"updateTrades\",\"params\":{{\"data\":[{0}],\"symbol\":\"{1}\"}}}}",
-                    dataParameters, symbol);
-            await _hitBtcSocketApi.Execute(request);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <param name="enPeriod"></param>
-        /// <param name="data"></param>
-        public async void NotificationSnapshotCandles(string symbol, PublicEnum.EnPeriod enPeriod, List<Candle> data)
-        {
-            string dataParameters = data.Aggregate(string.Empty,
-                (current, parameter) =>
-                    current +
-                    string.Format(
-                        " {{\"timestamp\":\"{0}\",\"open\":\"{1}\",\"close\":\"{2}\",\"min\":\"{3}\",\"max\":\"{4}\",\"volume\":\"{5}\",\"volumeQuote\":\"{6}\"}},",
-                        parameter.Timestamp, parameter.Open, parameter.Close, parameter.Min, parameter.Max,
-                        parameter.Volume, parameter.VolumeQuote));
-
-            dataParameters = dataParameters.TrimEnd(',');
-            var period = enPeriod.ToString() == "Month" ? "1M" : enPeriod.ToString();
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"snapshotCandles\",\"params\":{{\"data\":[{0}],\"symbol\":\"{1}\",\"period\":\"{2}\"}}}}",
-                    dataParameters, symbol, period);
-            await _hitBtcSocketApi.Execute(request);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <param name="enPeriod"></param>
-        /// <param name="data"></param>
-        public async void NotificationUpdateCandles(string symbol, PublicEnum.EnPeriod enPeriod, List<Candle> data)
-        {
-            string dataParameters = data.Aggregate(string.Empty,
-                (current, parameter) =>
-                    current +
-                    string.Format(
-                        " {{\"timestamp\":\"{0}\",\"open\":\"{1}\",\"close\":\"{2}\",\"min\":\"{3}\",\"max\":\"{4}\",\"volume\":\"{5}\",\"volumeQuote\":\"{6}\"}},",
-                        parameter.Timestamp, parameter.Open, parameter.Close, parameter.Min, parameter.Max,
-                        parameter.Volume, parameter.VolumeQuote));
-
-            dataParameters = dataParameters.TrimEnd(',');
-            var period = enPeriod.ToString() == "Month" ? "1M" : enPeriod.ToString();
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"updateCandles\",\"params\":{{\"data\":[{0}],\"symbol\":\"{1}\",\"period\":\"{2}\"}}}}",
-                    dataParameters, symbol, period);
-            await _hitBtcSocketApi.Execute(request);
+            var source = new TaskCompletionSource<T>();
+            source.SetException(new NotSupportedException("This request was removed from HitBTC WebSocket API v3."));
+            return source.Task;
         }
     }
 }
-

--- a/HitBtc/HitBtcCategories/SocketTrading.cs
+++ b/HitBtc/HitBtcCategories/SocketTrading.cs
@@ -1,147 +1,78 @@
-﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hitbtc.HitBtcModel;
+using Newtonsoft.Json.Linq;
 
 namespace Hitbtc.HitBtcCategories
 {
+    /// <summary>Authenticated spot commands for HitBTC WebSocket API v3.</summary>
     public class SocketTrading
     {
-        private readonly HitBtcSocketApi _hitBtcSocketApi;
-
-        public SocketTrading(HitBtcSocketApi hitBtcSocketApi)
-        {
-            _hitBtcSocketApi = hitBtcSocketApi;
-        }
-
+        private readonly HitBtcSocketApi _api;
+        public SocketTrading(HitBtcSocketApi api) { _api = api; }
 
         public async Task<SocketSubscribe> SubscribeReports(int id = 123)
         {
-            var request = "{ \"method\": \"subscribeReports\", \"params\": {  } }";
-            return await _hitBtcSocketApi.Execute(request, false);
+            return await Send<SocketSubscribe>("spot_subscribe", new JObject(), id);
         }
 
-        public async Task<SocketOrder> NewOrder(string symbolName, string clientOrderId, string quantity, string price,
-            int id = 123, PublicEnum.EnTradingSide side = PublicEnum.EnTradingSide.buy)
+        public async Task<SocketOrder> NewOrder(string symbolName, string clientOrderId,
+            string quantity, string price, int id = 123,
+            PublicEnum.EnTradingSide side = PublicEnum.EnTradingSide.buy)
         {
-            string[] paramterArray = new string[5];
-            if (!string.IsNullOrEmpty(symbolName))
-                paramterArray[0] = string.Format("\"symbol\": \"{0}\"", symbolName);
-            paramterArray[1] = string.Format("\"clientOrderId\": \"{0}\"", clientOrderId);
-            if (!string.IsNullOrEmpty(quantity))
-                paramterArray[2] = string.Format("\"quantity\": \"{0}\"", quantity);
-            if (!string.IsNullOrEmpty(price))
-                paramterArray[3] = string.Format("\"price\": \"{0}\"", price);
-            paramterArray[4] = string.Format("\"side\": \"{0}\"", side.ToString());
-
-            string parameters = string.Empty;
-
-            for (var index = 0; index < paramterArray.Length - 1; index++)
+            var parameters = new JObject
             {
-                if (!string.IsNullOrEmpty(paramterArray[index]))
-                    parameters += paramterArray[index] + " , ";
-            }
-
-            if (!string.IsNullOrEmpty(paramterArray[4]))
-                parameters += paramterArray[4];
-
-
-            var request =
-                      string.Format("{{ \"method\": \"newOrder\", \"params\": {{ {0} }}, \"id\": {1} }}",
-                      parameters, id);
-            return await _hitBtcSocketApi.Execute(request);
+                ["symbol"] = symbolName,
+                ["client_order_id"] = clientOrderId,
+                ["quantity"] = quantity,
+                ["side"] = side.ToString()
+            };
+            AddOptional(parameters, "price", price);
+            return await Send<SocketOrder>("spot_new_order", parameters, id);
         }
 
         public async Task<SocketOrder> CancelOrder(string clientOrderId, int id = 123)
         {
-            var request =
-                string.Format(
-                    "{{ \"method\": \"cancelOrder\", \"params\": {{ \"clientOrderId\": \"{0}\" }}, \"id\": {1} }}",
-                    clientOrderId, id);
-            return await _hitBtcSocketApi.Execute(request);
+            return await Send<SocketOrder>("spot_cancel_order",
+                new JObject { ["client_order_id"] = clientOrderId }, id);
         }
 
-        public async Task<SocketOrderReplace> CancelReplaceOrder(string clientOrderId, string requestClientId, string quantity,
-            string price, string strictValidate, int id = 123)
+        public async Task<SocketOrderReplace> CancelReplaceOrder(string clientOrderId,
+            string requestClientId, string quantity, string price, string strictValidate,
+            int id = 123)
         {
-
-            string[] paramterArray = new string[5];
-
-            paramterArray[0] = string.Format("\"clientOrderId\": \"{0}\"", clientOrderId);
-            if (!string.IsNullOrEmpty(requestClientId))
-                paramterArray[1] = string.Format("\"requestClientId\": \"{0}\"", requestClientId);
-            if (!string.IsNullOrEmpty(quantity))
-                paramterArray[2] = string.Format("\"quantity\": \"{0}\"", quantity);
-            if (!string.IsNullOrEmpty(price))
-                paramterArray[3] = string.Format("\"price\": \"{0}\"", price);
-            if (!string.IsNullOrEmpty(strictValidate))
-                paramterArray[4] = string.Format("\"strictValidate\": \"{0}\"", strictValidate);
-
-            string parameters = string.Empty;
-
-            for (var index = 0; index < paramterArray.Length - 1; index++)
-            {
-                if (!string.IsNullOrEmpty(paramterArray[index]))
-                    parameters += paramterArray[index] + " , ";
-            }
-
-            if (!string.IsNullOrEmpty(paramterArray[4]))
-                parameters += paramterArray[4];
-
-            var request = string.Format("{{ \"method\": \"cancelReplaceOrder\", \"params\": {{ {0} }}, \"id\": {1} }}",
-                parameters, id);
-            return await _hitBtcSocketApi.Execute(request);
+            var parameters = new JObject { ["client_order_id"] = clientOrderId };
+            AddOptional(parameters, "new_client_order_id", requestClientId);
+            AddOptional(parameters, "quantity", quantity);
+            AddOptional(parameters, "price", price);
+            if (bool.TryParse(strictValidate, out var strict)) parameters["strict_validate"] = strict;
+            return await Send<SocketOrderReplace>("spot_replace_order", parameters, id);
         }
-
 
         public async Task<SocketOrderReplace> GetActiveOrder(int id = 123)
         {
-            var request =
-                string.Format("{{ \"method\": \"getOrders\", \"params\": {{ }}, \"id\": {0} }}",id);
-            return await _hitBtcSocketApi.Execute(request);
+            return await Send<SocketOrderReplace>("spot_get_orders", new JObject(), id);
         }
 
         public async Task<SocketBalance> GetTradingBalance(int id = 123)
         {
-            var request =
-                string.Format("{{ \"method\": \"getTradingBalance\", \"params\": {{ }}, \"id\": {0} }}", id);
-            return await _hitBtcSocketApi.Execute(request);
+            return await Send<SocketBalance>("spot_get_trading_balance", new JObject(), id);
         }
 
-
-        public async void NotificationActiveOrders(string id, string clientOrderId, string symbol,
-            PublicEnum.EnTradingSide side,
-            PublicEnum.EnStatus status,
-            PublicEnum.EnTradingType type, PublicEnum.EnTradingTimeInForce timeInForce, string quantity, string price,
-            string cumQuantity, string createdAt,
-            string updatedAt,
-            PublicEnum.EnReportType reportType)
+        private async Task<T> Send<T>(string method, JObject parameters, int id) where T : class
         {
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"activeOrders\",\"params\":[{{\"id\":\"{0}\",\"clientOrderId\":\"{1}\",\"symbol\":\"{2}\",\"side\":\"{3}\",\"status\":\"{4}\",\"type\":\"{5}\",\"timeInForce\":\"{6}\",\"quantity\":\"{7}\",\"price\":\"{8}\",\"cumQuantity\":\"{9}\",\"createdAt\":\"{10}\",\"updatedAt\":\"{11}\",\"reportType\":\"{12}\"}}]}}",
-                    id, clientOrderId, symbol, side, Utilities.FirstCharToLower(status.ToString()),
-                    Utilities.FirstCharToLower(type.ToString()), timeInForce, quantity, price, cumQuantity, createdAt,
-                    updatedAt, reportType);
-            await _hitBtcSocketApi.Execute(request);
+            var request = new JObject
+            {
+                ["method"] = method,
+                ["params"] = parameters,
+                ["id"] = id
+            }.ToString(Newtonsoft.Json.Formatting.None);
+            var response = await _api.Execute(request);
+            return Utilities.ConvertFromJson<T>(response);
         }
 
-        public async void NotificationReport(string id, string clientOrderId, string symbol,
-            PublicEnum.EnTradingSide side,
-            PublicEnum.EnStatus status,
-            PublicEnum.EnTradingType type, PublicEnum.EnTradingTimeInForce timeInForce, string quantity, string price,
-            string cumQuantity, string createdAt,
-            string updatedAt,
-            PublicEnum.EnReportType reportType, string tradeQuantity, string tradePrice, string tradeId,
-            string tradeFee)
+        private static void AddOptional(JObject parameters, string name, string value)
         {
-            var request =
-                string.Format(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"report\",\"params\":{{\"id\":\"{0}\",\"clientOrderId\":\"{1}\",\"symbol\":\"{2}\",\"side\":\"{3}\",\"status\":\"{4}\",\"type\":\"{5}\",\"timeInForce\":\"{6}\",\"quantity\":\"{7}\",\"price\":\"{8}\",\"cumQuantity\":\"{9}\",\"createdAt\":\"{10}\",\"updatedAt\":\"{11}\",\"reportType\":\"{12}\",\"tradeQuantity\":\"{13}\",\"tradePrice\":\"{14}\",\"tradeId\":{15},\"tradeFee\":\"{16}\"}}}}",
-                    id, clientOrderId, symbol, side, Utilities.FirstCharToLower(status.ToString()),
-                    Utilities.FirstCharToLower(type.ToString()), timeInForce, quantity, price, cumQuantity, createdAt,
-                    updatedAt, reportType, tradeQuantity, tradePrice, tradeId, tradeFee);
-            await _hitBtcSocketApi.Execute(request);
+            if (!string.IsNullOrWhiteSpace(value)) parameters[name] = value;
         }
-
     }
 }

--- a/HitBtc/HitBtcModel/Address.cs
+++ b/HitBtc/HitBtcModel/Address.cs
@@ -8,7 +8,13 @@ namespace Hitbtc.HitBtcModel
         [JsonProperty("address")]
         public string Address { get; set; }
 
-        [JsonProperty("paymentId")]
+        [JsonProperty("payment_id")]
         public string PaymentId { get; set; }
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+        [JsonProperty("network_code")]
+        public string NetworkCode { get; set; }
+        [JsonProperty("public_key")]
+        public string PublicKey { get; set; }
     }
 }

--- a/HitBtc/HitBtcModel/Balance.cs
+++ b/HitBtc/HitBtcModel/Balance.cs
@@ -13,5 +13,11 @@ namespace Hitbtc.HitBtcModel
         [JsonProperty("reserved")]
         public string Reserved { get; set; }
 
+        [JsonProperty("reserved_margin")]
+        public string ReservedMargin { get; set; }
+
+        [JsonProperty("cross_margin_reserved")]
+        public string CrossMarginReserved { get; set; }
+
     }
 }

--- a/HitBtc/HitBtcModel/Candle.cs
+++ b/HitBtc/HitBtcModel/Candle.cs
@@ -14,7 +14,7 @@ namespace Hitbtc.HitBtcModel
         public string Max { get; set; }
         [JsonProperty("volume")]
         public string Volume { get; set; }
-        [JsonProperty("volumeQuote")]
+        [JsonProperty("volume_quote")]
         public string VolumeQuote { get; set; }
         [JsonProperty("timestamp")]
         public string Timestamp { get; set; }

--- a/HitBtc/HitBtcModel/Currency.cs
+++ b/HitBtc/HitBtcModel/Currency.cs
@@ -7,38 +7,81 @@ namespace Hitbtc.HitBtcModel
         [JsonProperty("id")]
         public string Id { get; set; }
 
-        [JsonProperty("fullName")]
+        [JsonProperty("full_name")]
         public string FullName { get; set; }
 
         [JsonProperty("crypto")]
         public bool Crypto { get; set; }
+
+        [JsonProperty("stable")]
+        public bool Stable { get; set; }
         //True for cryptocurrencies, false for fiat, ICO and others.
 
-        [JsonProperty("payinEnabled")]
+        [JsonProperty("payin_enabled")]
         public bool PayinEnabled { get; set; }
         //True if cryptocurrency support generate adress or paymentId for deposits
 
-        [JsonProperty("payinPaymentId")]
+        [JsonProperty("payin_payment_id")]
         public bool PayinPaymentId { get; set; }
         // True if cryptocurrency requred use paymentId for deposits
 
-        [JsonProperty("payinConfirmations")]
+        [JsonProperty("payin_confirmations")]
         public int PayinConfirmations { get; set; }
         //Confirmations count for cryptocurrency deposits
 
-        [JsonProperty("payoutEnabled")]
+        [JsonProperty("payout_enabled")]
         public bool PayoutEnabled { get; set; }
 
-        [JsonProperty("payoutFee")]
+        [JsonProperty("payout_fee")]
         public string PayoutFee { get; set; }
 
-        [JsonProperty("payoutIsPaymentId")]
+        [JsonProperty("payout_is_payment_id")]
         public bool PayoutIsPaymentId { get; set; }
 
         [JsonProperty("delisted")]
         public bool Delisted { get; set; }
 
-        [JsonProperty("transferEnabled")]
+        [JsonProperty("transfer_enabled")]
         public bool TransferEnabled { get; set; }
+
+        [JsonProperty("precision_transfer")]
+        public string PrecisionTransfer { get; set; }
+
+        [JsonProperty("transfer_to_wallet_enabled")]
+        public bool TransferToWalletEnabled { get; set; }
+
+        [JsonProperty("transfer_to_exchange_enabled")]
+        public bool TransferToExchangeEnabled { get; set; }
+
+        [JsonProperty("networks")]
+        public System.Collections.Generic.List<CurrencyNetwork> Networks { get; set; }
+    }
+
+    public class CurrencyNetwork
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+        [JsonProperty("network_name")]
+        public string NetworkName { get; set; }
+        [JsonProperty("network")]
+        public string Network { get; set; }
+        [JsonProperty("protocol")]
+        public string Protocol { get; set; }
+        [JsonProperty("default")]
+        public bool Default { get; set; }
+        [JsonProperty("payin_enabled")]
+        public bool PayinEnabled { get; set; }
+        [JsonProperty("payout_enabled")]
+        public bool PayoutEnabled { get; set; }
+        [JsonProperty("precision_payout")]
+        public string PrecisionPayout { get; set; }
+        [JsonProperty("payout_fee")]
+        public string PayoutFee { get; set; }
+        [JsonProperty("payout_is_payment_id")]
+        public bool PayoutIsPaymentId { get; set; }
+        [JsonProperty("payin_payment_id")]
+        public bool PayinPaymentId { get; set; }
+        [JsonProperty("payin_confirmations")]
+        public int PayinConfirmations { get; set; }
     }
 }

--- a/HitBtc/HitBtcModel/Error.cs
+++ b/HitBtc/HitBtcModel/Error.cs
@@ -7,7 +7,7 @@ namespace Hitbtc.HitBtcModel
         [JsonProperty("code")]
         public string Code { get; set; }
         [JsonProperty("message")]
-        public int Message { get; set; }
+        public string Message { get; set; }
         [JsonProperty("description")]
         public string Description { get; set; }
         public override string ToString()

--- a/HitBtc/HitBtcModel/Fee.cs
+++ b/HitBtc/HitBtcModel/Fee.cs
@@ -4,10 +4,10 @@ namespace Hitbtc.HitBtcModel
 {
     public class Fee
     {
-        [JsonProperty("takeLiquidityRate")]
+        [JsonProperty("take_rate")]
         public string TakeLiquidityRate { get; set; }
 
-        [JsonProperty("provideLiquidityRate")]
+        [JsonProperty("make_rate")]
         public string ProvideLiquidityRate { get; set; }
 
     }

--- a/HitBtc/HitBtcModel/OrderBookParameterConverter.cs
+++ b/HitBtc/HitBtcModel/OrderBookParameterConverter.cs
@@ -1,0 +1,38 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hitbtc.HitBtcModel
+{
+    internal sealed class OrderBookParameterConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(OrderBookParamter);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            var value = JToken.Load(reader);
+            var pair = value as JArray;
+            if (pair == null || pair.Count < 2)
+                throw new JsonSerializationException("An API v3 order-book entry must contain price and size.");
+
+            return new OrderBookParamter
+            {
+                Price = pair[0].Value<string>(),
+                Size = pair[1].Value<string>()
+            };
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var entry = (OrderBookParamter)value;
+            writer.WriteStartArray();
+            writer.WriteValue(entry.Price);
+            writer.WriteValue(entry.Size);
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/HitBtc/HitBtcModel/Orderbook.cs
+++ b/HitBtc/HitBtcModel/Orderbook.cs
@@ -13,6 +13,7 @@ namespace Hitbtc.HitBtcModel
         public string Timestamp { get; set; }
     }
 
+    [JsonConverter(typeof(OrderBookParameterConverter))]
     public class OrderBookParamter
     {
         [JsonProperty("price")]

--- a/HitBtc/HitBtcModel/Orders.cs
+++ b/HitBtc/HitBtcModel/Orders.cs
@@ -8,19 +8,19 @@ namespace Hitbtc.HitBtcModel
         /// Unique identifier for Order as assigned by exchange
         /// </summary>
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// String 	Unique identifier for Order as assigned by trader. Uniqueness must be guaranteed within a single trading day, including all active orders.
         /// </summary>
-        [JsonProperty("clientOrderId")]
+        [JsonProperty("client_order_id")]
         public string ClientOrderId { get; set; }
 
         /// <summary>
         /// Trading symbol
         /// </summary>
         [JsonProperty("symbol")]
-        public long Symbol { get; set; }
+        public string Symbol { get; set; }
 
         /// <summary>
         /// sell buy
@@ -32,7 +32,7 @@ namespace Hitbtc.HitBtcModel
         /// new, suspended, partiallyFilled, filled, canceled, expired
         /// </summary>
         [JsonProperty("status")]
-        public int Status { get; set; }
+        public string Status { get; set; }
 
         /// <summary>
         /// limit, market, stopLimit, stopMarket
@@ -44,8 +44,8 @@ namespace Hitbtc.HitBtcModel
         /// Time in force
         /// GTC - Good-Til-Canceled, IOC - Immediate-Or-Cancel, OK - Fill-Or-Kill, DAY - day
         /// </summary>
-        [JsonProperty("timeInForce")]
-        public int TimeInForce { get; set; }
+        [JsonProperty("time_in_force")]
+        public string TimeInForce { get; set; }
 
         /// <summary>
         /// Number 	Order quantity
@@ -62,31 +62,37 @@ namespace Hitbtc.HitBtcModel
         /// <summary>
         /// Cumulative executed quantity
         /// </summary>
-        [JsonProperty("cumQuantity")]
-        public int CumQuantity { get; set; }
+        [JsonProperty("quantity_cumulative")]
+        public string CumQuantity { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
-        [JsonProperty("createdAt")]
+        [JsonProperty("created_at")]
         public string CreatedAt { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
-        [JsonProperty("updatedAt")]
+        [JsonProperty("updated_at")]
         public string UpdatedAt { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
-        [JsonProperty("stopPrice")]
+        [JsonProperty("stop_price")]
         public string StopPrice { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
-        [JsonProperty("expireTime")]
-        public int ExpireTime { get; set; }
+        [JsonProperty("expire_time")]
+        public string ExpireTime { get; set; }
+
+        [JsonProperty("price_average")]
+        public string PriceAverage { get; set; }
+
+        [JsonProperty("post_only")]
+        public bool PostOnly { get; set; }
     }
 }

--- a/HitBtc/HitBtcModel/SocketOrder.cs
+++ b/HitBtc/HitBtcModel/SocketOrder.cs
@@ -27,7 +27,7 @@ namespace Hitbtc.HitBtcModel
     {
         [JsonProperty("id")]
         public string Id { get; set; }
-        [JsonProperty("clientOrderId")]
+        [JsonProperty("client_order_id")]
         public string ClientOrderId { get; set; }
         [JsonProperty("symbol")]
         public string Symbol { get; set; }
@@ -37,19 +37,19 @@ namespace Hitbtc.HitBtcModel
         public string Status { get; set; }
         [JsonProperty("type")]
         public string Type { get; set; }
-        [JsonProperty("timeInForce")]
+        [JsonProperty("time_in_force")]
         public string TimeInForce { get; set; }
         [JsonProperty("quantity")]
         public string Quantity { get; set; }
         [JsonProperty("price")]
         public string Price { get; set; }
-        [JsonProperty("cumQuantity")]
+        [JsonProperty("quantity_cumulative")]
         public string CumQuantity { get; set; }
-        [JsonProperty("createdAt")]
+        [JsonProperty("created_at")]
         public string CreatedAt { get; set; }
-        [JsonProperty("updatedAt")]
+        [JsonProperty("updated_at")]
         public string UpdatedAt { get; set; }
-        [JsonProperty("reportType")]
+        [JsonProperty("report_type")]
         public string ReportType { get; set; }
     }
 
@@ -57,7 +57,7 @@ namespace Hitbtc.HitBtcModel
     {
         [JsonProperty("id")]
         public string Id { get; set; }
-        [JsonProperty("clientOrderId")]
+        [JsonProperty("client_order_id")]
         public string ClientOrderId { get; set; }
         [JsonProperty("symbol")]
         public string Symbol { get; set; }
@@ -67,21 +67,21 @@ namespace Hitbtc.HitBtcModel
         public string Status { get; set; }
         [JsonProperty("type")]
         public string Type { get; set; }
-        [JsonProperty("timeInForce")]
+        [JsonProperty("time_in_force")]
         public string TimeInForce { get; set; }
         [JsonProperty("quantity")]
         public string Quantity { get; set; }
         [JsonProperty("price")]
         public string Price { get; set; }
-        [JsonProperty("cumQuantity")]
+        [JsonProperty("quantity_cumulative")]
         public string CumQuantity { get; set; }
-        [JsonProperty("createdAt")]
+        [JsonProperty("created_at")]
         public string CreatedAt { get; set; }
-        [JsonProperty("updatedAt")]
+        [JsonProperty("updated_at")]
         public string UpdatedAt { get; set; }
-        [JsonProperty("reportType")]
+        [JsonProperty("report_type")]
         public string ReportType { get; set; }
-        [JsonProperty("originalRequestClientOrderId")]
+        [JsonProperty("original_request_client_order_id")]
         public string OriginalRequestClientOrderId { get; set; }
     }
 }

--- a/HitBtc/HitBtcModel/Symbols.cs
+++ b/HitBtc/HitBtcModel/Symbols.cs
@@ -6,19 +6,27 @@ namespace Hitbtc.HitBtcModel
     {
         [JsonProperty("id")]
         public string Id { get; set; }
-        [JsonProperty("baseCurrency")]
+        [JsonProperty("base_currency")]
         public string BaseCurrency { get; set; }
-        [JsonProperty("quoteCurrency")]
+        [JsonProperty("quote_currency")]
         public string QuoteCurrency { get; set; }
-        [JsonProperty("quantityIncrement")]
+        [JsonProperty("quantity_increment")]
         public string QuantityIncrement { get; set; }
-        [JsonProperty("tickSize")]
+        [JsonProperty("tick_size")]
         public string TickSize { get; set; }
-        [JsonProperty("takeLiquidityRate")]
+        [JsonProperty("take_rate")]
         public string TakeLiquidityRate { get; set; }
-        [JsonProperty("provideLiquidityRate")]
+        [JsonProperty("make_rate")]
         public string ProvideLiquidityRate { get; set; }
-        [JsonProperty("feeCurrency")]
+        [JsonProperty("fee_currency")]
         public string FeeCurrency { get; set; }
+        [JsonProperty("type")]
+        public string Type { get; set; }
+        [JsonProperty("status")]
+        public string Status { get; set; }
+        [JsonProperty("margin_trading")]
+        public bool MarginTrading { get; set; }
+        [JsonProperty("max_initial_leverage")]
+        public string MaxInitialLeverage { get; set; }
     }
 }

--- a/HitBtc/HitBtcModel/Ticker.cs
+++ b/HitBtc/HitBtcModel/Ticker.cs
@@ -52,7 +52,7 @@ namespace Hitbtc.HitBtcModel
         /// <summary>
         /// Volume in second currency per last 24h + last incomplete minute
         /// </summary>
-        [JsonProperty("volumeQuote")]
+        [JsonProperty("volume_quote")]
         public string VolumeQuote { get; set; }
 
         /// <summary>

--- a/HitBtc/HitBtcModel/Trades.cs
+++ b/HitBtc/HitBtcModel/Trades.cs
@@ -6,8 +6,8 @@ namespace Hitbtc.HitBtcModel
     {
         [JsonProperty("id")]
         public int Id { get; set; }
-        [JsonProperty("orderId")]
-        public int OrderId { get; set; }
+        [JsonProperty("order_id")]
+        public long OrderId { get; set; }
         [JsonProperty("symbol")]
         public string Symbol { get; set; }
         [JsonProperty("side")]
@@ -26,10 +26,13 @@ namespace Hitbtc.HitBtcModel
     {
         [JsonProperty("id")]
         public int Id { get; set; }
-        [JsonProperty("clientOrderId")]
-        public int ClientOrderId { get; set; }
-        [JsonProperty("orderId")]
-        public int OrderId { get; set; }
+        [JsonProperty("client_order_id")]
+        public string ClientOrderId { get; set; }
+        [JsonProperty("order_id")]
+        public long OrderId { get; set; }
+
+        [JsonProperty("taker")]
+        public bool Taker { get; set; }
         [JsonProperty("symbol")]
         public string Symbol { get; set; }
         [JsonProperty("side")]

--- a/HitBtc/HitBtcModel/Transaction.cs
+++ b/HitBtc/HitBtcModel/Transaction.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Hitbtc.HitBtcModel
 {
@@ -6,28 +6,43 @@ namespace Hitbtc.HitBtcModel
     {
         [JsonProperty("id")]
         public string Id { get; set; }
-        [JsonProperty("index")]
-        public string Index { get; set; }
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
-        [JsonProperty("amount")]
-        public int Amount { get; set; }
-        [JsonProperty("fee")]
-        public int Fee { get; set; }
-        [JsonProperty("address")]
-        public double Address { get; set; }
-        [JsonProperty("paymentId")]
-        public string PaymentId { get; set; }
-        [JsonProperty("hash")]
-        public double Hash { get; set; }
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; }
+        [JsonProperty("last_activity_at")]
+        public string LastActivityAt { get; set; }
         [JsonProperty("status")]
         public string Status { get; set; }
         [JsonProperty("type")]
-        public object Type { get; set; }
-        [JsonProperty("createdAt")]
-        public int CreatedAt { get; set; }
-        [JsonProperty("updatedAt")]
-        public string UpdatedAt { get; set; }
+        public string Type { get; set; }
+        [JsonProperty("subtype")]
+        public string Subtype { get; set; }
+        [JsonProperty("native")]
+        public TransactionNative Native { get; set; }
     }
 
+    public class TransactionNative
+    {
+        [JsonProperty("tx_id")]
+        public string TransactionId { get; set; }
+        [JsonProperty("index")]
+        public long? Index { get; set; }
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+        [JsonProperty("amount")]
+        public string Amount { get; set; }
+        [JsonProperty("fee")]
+        public string Fee { get; set; }
+        [JsonProperty("address")]
+        public string Address { get; set; }
+        [JsonProperty("payment_id")]
+        public string PaymentId { get; set; }
+        [JsonProperty("hash")]
+        public string Hash { get; set; }
+        [JsonProperty("network_code")]
+        public string NetworkCode { get; set; }
+        [JsonProperty("protocol_code")]
+        public string ProtocolCode { get; set; }
+    }
 }

--- a/HitBtc/HitBtcRestApi.cs
+++ b/HitBtc/HitBtcRestApi.cs
@@ -18,8 +18,7 @@ namespace Hitbtc
 //    504 Gateway Timeout. Request timeout expired
 
     /// <summary>
-    /// https://api.hitbtc.com/api/2/explore/
-    /// https://api.hitbtc.com/
+    /// HitBTC API v3 client. See https://api.hitbtc.com/api/3/explore/.
     /// </summary>
     public class HitBtcRestApi
     {

--- a/HitBtc/HitBtcRestApi.cs
+++ b/HitBtc/HitBtcRestApi.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Hitbtc.HitBtcCategories;
 using RestSharp;
 using RestSharp.Authenticators;
+using Newtonsoft.Json.Linq;
 
 namespace Hitbtc
 {
@@ -25,14 +26,20 @@ namespace Hitbtc
         private const string Url = "https://api.hitbtc.com";
         private  string _apiKey;
         private  string _secretKey;
+        private readonly IRestTransport _transport;
 
         public RestTrading Trading { get; set; }
         public RestAccount Account { get; set; }
         public RestPublicData PublicData { get; set; }
         public RestTradingHistory TradingHistory { get; set; }
 
-        public HitBtcRestApi()
+        public HitBtcRestApi() : this(new RestSharpTransport())
         {
+        }
+
+        internal HitBtcRestApi(IRestTransport transport)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
             PublicData = new RestPublicData(this);
             TradingHistory = new RestTradingHistory(this);
             Trading = new RestTrading(this);
@@ -64,25 +71,44 @@ namespace Hitbtc
             if (requireAuthentication)
                 options.Authenticator = new HttpBasicAuthenticator(_apiKey, _secretKey);
 
-            using (var client = new RestClient(options))
+            var response = await _transport.ExecuteAsync(request, options, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (response.ErrorException != null || !response.IsSuccessful)
             {
-                var response = await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
-
-                if (response.ErrorException != null || !response.IsSuccessful)
-                {
-                    var message = string.Format("HitBTC request failed with HTTP status {0} ({1}).",
-                        (int)response.StatusCode, response.StatusDescription);
-                    throw new ApplicationException(message, response.ErrorException);
-                }
-
-                return new ApiResponse { Content = response.Content };
+                var apiError = TryReadApiError(response.Content);
+                var message = apiError == null
+                    ? string.Format("HitBTC request failed with HTTP status {0} ({1}).",
+                        (int)response.StatusCode, response.StatusDescription)
+                    : string.Format("HitBTC request failed: {0}", apiError.Value.Message);
+                throw new HitBtcApiException(message, response.StatusCode,
+                    apiError?.Code, response.ErrorException);
             }
+
+            return new ApiResponse { Content = response.Content };
         }
 
         /// <summary>
         /// Flag shows that user is authorized
         /// </summary>
-        public bool IsAuthorized { get; set; }
+        public bool IsAuthorized { get; private set; }
+
+        private static (string Code, string Message)? TryReadApiError(string content)
+        {
+            if (string.IsNullOrWhiteSpace(content)) return null;
+            try
+            {
+                var root = JObject.Parse(content);
+                var error = root["error"] as JObject ?? root;
+                var message = error.Value<string>("message") ?? error.Value<string>("description");
+                if (string.IsNullOrWhiteSpace(message)) return null;
+                return (error.Value<string>("code"), message);
+            }
+            catch (Newtonsoft.Json.JsonException)
+            {
+                return null;
+            }
+        }
 
         /// <summary>
         /// Method for authorization 

--- a/HitBtc/HitBtcSocketApi.cs
+++ b/HitBtc/HitBtcSocketApi.cs
@@ -27,7 +27,7 @@ namespace Hitbtc
 
         public SocketMarketData MarketData { get; set; }
         public SocketTrading Trading { get; set; }
-        public bool IsAuthorized { get; set; }
+        public bool IsAuthorized { get; private set; }
 
         public HitBtcSocketApi() : this(new WebSocketClientAdapter(), new WebSocketClientAdapter()) { }
 
@@ -53,6 +53,7 @@ namespace Hitbtc
             ThrowIfDisposed();
             if (string.IsNullOrWhiteSpace(request))
                 throw new ArgumentException("The JSON-RPC request cannot be empty.", nameof(request));
+            EnsureValidRequest(request);
             if (requireAuthentication && !IsAuthorized)
                 throw new InvalidOperationException("The request requires authorization. Call Authorize first.");
 
@@ -66,7 +67,9 @@ namespace Hitbtc
                     await Authenticate(socket, cancellationToken).ConfigureAwait(false);
 
                 await SendCommand(socket, request, cancellationToken).ConfigureAwait(false);
-                return new ApiResponse { Content = await Receive(socket, cancellationToken).ConfigureAwait(false) };
+                var content = await Receive(socket, cancellationToken).ConfigureAwait(false);
+                ValidateResponse(request, content);
+                return new ApiResponse { Content = content };
             }
             finally
             {
@@ -99,10 +102,71 @@ namespace Hitbtc
             }.ToString(Newtonsoft.Json.Formatting.None);
 
             await SendCommand(socket, loginRequest, cancellationToken).ConfigureAwait(false);
-            var response = JObject.Parse(await Receive(socket, cancellationToken).ConfigureAwait(false));
-            if (response["error"] != null || response["result"] == null)
-                throw new InvalidOperationException("HitBTC WebSocket authentication failed.");
+            JObject response;
+            try
+            {
+                response = JObject.Parse(await Receive(socket, cancellationToken).ConfigureAwait(false));
+            }
+            catch (Newtonsoft.Json.JsonException exception)
+            {
+                throw new HitBtcWebSocketException("HitBTC returned malformed authentication JSON.", null, exception);
+            }
+            if (response["error"] != null || response["result"] == null ||
+                response["result"].Type == JTokenType.Boolean && !response["result"].Value<bool>())
+                throw CreateWebSocketError(response, "HitBTC WebSocket authentication failed.");
             _connectionAuthenticated = true;
+        }
+
+        private static void ValidateResponse(string requestContent, string responseContent)
+        {
+            JObject response;
+            try
+            {
+                response = JObject.Parse(responseContent);
+            }
+            catch (Newtonsoft.Json.JsonException exception)
+            {
+                throw new HitBtcWebSocketException("HitBTC returned malformed WebSocket JSON.", null, exception);
+            }
+
+            if (response["error"] != null)
+                throw CreateWebSocketError(response, "HitBTC WebSocket request failed.");
+
+            try
+            {
+                var request = JObject.Parse(requestContent);
+                var requestId = request["id"];
+                if (requestId != null && !JToken.DeepEquals(requestId, response["id"]))
+                    throw new HitBtcWebSocketException("HitBTC WebSocket response ID did not match the request ID.");
+            }
+            catch (Newtonsoft.Json.JsonException exception)
+            {
+                throw new ArgumentException("The WebSocket request must contain valid JSON.",
+                    nameof(requestContent), exception);
+            }
+        }
+
+        private static void EnsureValidRequest(string request)
+        {
+            try
+            {
+                JObject.Parse(request);
+            }
+            catch (Newtonsoft.Json.JsonException exception)
+            {
+                throw new ArgumentException("The WebSocket request must contain valid JSON.",
+                    nameof(request), exception);
+            }
+        }
+
+        private static HitBtcWebSocketException CreateWebSocketError(JObject response,
+            string fallbackMessage)
+        {
+            var error = response["error"] as JObject;
+            var code = error?.Value<string>("code");
+            var message = error?.Value<string>("message") ?? error?.Value<string>("description")
+                ?? fallbackMessage;
+            return new HitBtcWebSocketException(message, code);
         }
 
         private static Task SendCommand(IWebSocketClient socket, string jsonCommand,

--- a/HitBtc/HitBtcSocketApi.cs
+++ b/HitBtc/HitBtcSocketApi.cs
@@ -12,11 +12,14 @@ namespace Hitbtc
     /// <summary>Provides JSON-RPC access to the HitBTC WebSocket API.</summary>
     public class HitBtcSocketApi : IDisposable
     {
-        private const string Endpoint = "wss://api.hitbtc.com/api/2/ws";
+        private const string PublicEndpoint = "wss://api.hitbtc.com/api/3/ws/public";
+        private const string TradingEndpoint = "wss://api.hitbtc.com/api/3/ws/trading";
         private const int ReceiveBufferSize = 8192;
         private const int MaximumMessageSize = 1024 * 1024;
-        private readonly IWebSocketClient _clientWebSocket;
-        private readonly SemaphoreSlim _operationLock = new SemaphoreSlim(1, 1);
+        private readonly IWebSocketClient _publicSocket;
+        private readonly IWebSocketClient _tradingSocket;
+        private readonly SemaphoreSlim _publicLock = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _tradingLock = new SemaphoreSlim(1, 1);
         private string _apiKey;
         private string _secretKey;
         private bool _connectionAuthenticated;
@@ -26,11 +29,14 @@ namespace Hitbtc
         public SocketTrading Trading { get; set; }
         public bool IsAuthorized { get; set; }
 
-        public HitBtcSocketApi() : this(new WebSocketClientAdapter()) { }
+        public HitBtcSocketApi() : this(new WebSocketClientAdapter(), new WebSocketClientAdapter()) { }
 
-        internal HitBtcSocketApi(IWebSocketClient clientWebSocket)
+        internal HitBtcSocketApi(IWebSocketClient clientWebSocket) : this(clientWebSocket, clientWebSocket) { }
+
+        internal HitBtcSocketApi(IWebSocketClient publicSocket, IWebSocketClient tradingSocket)
         {
-            _clientWebSocket = clientWebSocket ?? throw new ArgumentNullException(nameof(clientWebSocket));
+            _publicSocket = publicSocket ?? throw new ArgumentNullException(nameof(publicSocket));
+            _tradingSocket = tradingSocket ?? throw new ArgumentNullException(nameof(tradingSocket));
             MarketData = new SocketMarketData(this);
             Trading = new SocketTrading(this);
         }
@@ -50,32 +56,36 @@ namespace Hitbtc
             if (requireAuthentication && !IsAuthorized)
                 throw new InvalidOperationException("The request requires authorization. Call Authorize first.");
 
-            await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var socket = requireAuthentication ? _tradingSocket : _publicSocket;
+            var operationLock = requireAuthentication ? _tradingLock : _publicLock;
+            await operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                await EnsureConnected(cancellationToken).ConfigureAwait(false);
+                await EnsureConnected(socket, requireAuthentication, cancellationToken).ConfigureAwait(false);
                 if (requireAuthentication && !_connectionAuthenticated)
-                    await Authenticate(cancellationToken).ConfigureAwait(false);
+                    await Authenticate(socket, cancellationToken).ConfigureAwait(false);
 
-                await SendCommand(request, cancellationToken).ConfigureAwait(false);
-                return new ApiResponse { Content = await Receive(cancellationToken).ConfigureAwait(false) };
+                await SendCommand(socket, request, cancellationToken).ConfigureAwait(false);
+                return new ApiResponse { Content = await Receive(socket, cancellationToken).ConfigureAwait(false) };
             }
             finally
             {
-                _operationLock.Release();
+                operationLock.Release();
             }
         }
 
-        private async Task EnsureConnected(CancellationToken cancellationToken)
+        private static async Task EnsureConnected(IWebSocketClient socket, bool trading,
+            CancellationToken cancellationToken)
         {
-            if (_clientWebSocket.State == WebSocketState.Open)
+            if (socket.State == WebSocketState.Open)
                 return;
-            if (_clientWebSocket.State != WebSocketState.None)
-                throw new WebSocketException("The WebSocket is not connectable: " + _clientWebSocket.State);
-            await _clientWebSocket.ConnectAsync(new Uri(Endpoint), cancellationToken).ConfigureAwait(false);
+            if (socket.State != WebSocketState.None)
+                throw new WebSocketException("The WebSocket is not connectable: " + socket.State);
+            var endpoint = trading ? TradingEndpoint : PublicEndpoint;
+            await socket.ConnectAsync(new Uri(endpoint), cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task Authenticate(CancellationToken cancellationToken)
+        private async Task Authenticate(IWebSocketClient socket, CancellationToken cancellationToken)
         {
             var loginRequest = new JObject
             {
@@ -88,28 +98,29 @@ namespace Hitbtc
                 }
             }.ToString(Newtonsoft.Json.Formatting.None);
 
-            await SendCommand(loginRequest, cancellationToken).ConfigureAwait(false);
-            var response = JObject.Parse(await Receive(cancellationToken).ConfigureAwait(false));
+            await SendCommand(socket, loginRequest, cancellationToken).ConfigureAwait(false);
+            var response = JObject.Parse(await Receive(socket, cancellationToken).ConfigureAwait(false));
             if (response["error"] != null || response["result"] == null)
                 throw new InvalidOperationException("HitBTC WebSocket authentication failed.");
             _connectionAuthenticated = true;
         }
 
-        private Task SendCommand(string jsonCommand, CancellationToken cancellationToken)
+        private static Task SendCommand(IWebSocketClient socket, string jsonCommand,
+            CancellationToken cancellationToken)
         {
             var bytes = Encoding.UTF8.GetBytes(jsonCommand);
-            return _clientWebSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true,
+            return socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true,
                 cancellationToken);
         }
 
-        private async Task<string> Receive(CancellationToken cancellationToken)
+        private static async Task<string> Receive(IWebSocketClient socket, CancellationToken cancellationToken)
         {
             var buffer = new byte[ReceiveBufferSize];
             using (var message = new MemoryStream())
             {
                 while (true)
                 {
-                    var result = await _clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken)
+                    var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken)
                         .ConfigureAwait(false);
                     if (result.MessageType == WebSocketMessageType.Close)
                         throw new WebSocketException("The server closed the WebSocket connection.");
@@ -141,8 +152,10 @@ namespace Hitbtc
         public void Dispose()
         {
             if (_disposed) return;
-            _clientWebSocket.Dispose();
-            _operationLock.Dispose();
+            _publicSocket.Dispose();
+            if (!ReferenceEquals(_publicSocket, _tradingSocket)) _tradingSocket.Dispose();
+            _publicLock.Dispose();
+            _tradingLock.Dispose();
             _disposed = true;
         }
 

--- a/HitBtc/Hitbtc.csproj
+++ b/HitBtc/Hitbtc.csproj
@@ -80,6 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiResponse.cs" />
+    <Compile Include="HitBtcApiException.cs" />
     <Compile Include="HitBtcCategories\RestAccount.cs" />
     <Compile Include="HitBtcCategories\SocketMarketData.cs" />
     <Compile Include="HitBtcCategories\RestPublicData.cs" />
@@ -93,6 +94,7 @@
     <Compile Include="HitBtcModel\SocketSymbol.cs" />
     <Compile Include="HitBtcModel\SocketTrade.cs" />
     <Compile Include="HitBtcRestApi.cs" />
+    <Compile Include="RestTransport.cs" />
     <Compile Include="HitBtcSocketApi.cs" />
     <Compile Include="HitBtcModel\Address.cs" />
     <Compile Include="HitBtcModel\Balance.cs" />

--- a/HitBtc/Hitbtc.csproj
+++ b/HitBtc/Hitbtc.csproj
@@ -102,6 +102,7 @@
     <Compile Include="HitBtcModel\Fee.cs" />
     <Compile Include="HitBtcModel\Id.cs" />
     <Compile Include="HitBtcModel\Orderbook.cs" />
+    <Compile Include="HitBtcModel\OrderBookParameterConverter.cs" />
     <Compile Include="HitBtcModel\Orders.cs" />
     <Compile Include="HitBtcModel\Symbols.cs" />
     <Compile Include="HitBtcModel\Ticker.cs" />

--- a/HitBtc/Properties/AssemblyInfo.cs
+++ b/HitBtc/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Hitbtc")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Unofficial .NET Framework client for HitBTC API v3")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Hitbtc")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyCopyright("Copyright © 2026 iarash84 and contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/HitBtc/RestTransport.cs
+++ b/HitBtc/RestTransport.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using RestSharp;
+
+namespace Hitbtc
+{
+    internal interface IRestTransport
+    {
+        Task<RestResponse> ExecuteAsync(RestRequest request, RestClientOptions options,
+            CancellationToken cancellationToken);
+    }
+
+    internal sealed class RestSharpTransport : IRestTransport
+    {
+        public async Task<RestResponse> ExecuteAsync(RestRequest request, RestClientOptions options,
+            CancellationToken cancellationToken)
+        {
+            using (var client = new RestClient(options))
+                return await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/HitBtc/Utilities.cs
+++ b/HitBtc/Utilities.cs
@@ -41,6 +41,15 @@ namespace Hitbtc
             return result;
         }
 
+        public static Dictionary<string, T> ConvertDictionaryFromJson<T>(ApiResponse response) where T : class
+        {
+            EnsureResponseContent(response);
+            var result = JsonConvert.DeserializeObject<Dictionary<string, T>>(response.Content);
+            if (result == null)
+                throw new JsonSerializationException("The API response JSON contained no dictionary.");
+            return result;
+        }
+
         private static void EnsureResponseContent(ApiResponse response)
         {
             if (response == null)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 iarash84 and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Trading, Trading History, Account, and socket Trading buttons do. The demo only
 reads public/private data or creates a subscription; it does not submit orders,
 transfers, or withdrawals.
 
+The redesigned console groups public REST, private REST, and WebSocket actions.
+It provides an editable symbol, masked credential fields, tabular responses, a
+status indicator, and a timestamped activity log containing request duration and
+typed API errors. Credentials can be loaded from the environment without being
+written to the log.
+
 ## Development workflow
 
 The `master` branch is protected. Make each logical change on a feature branch
@@ -386,6 +392,8 @@ dotnet run --project Test/Test.csproj
 <div dir="rtl" align="right">
 
 برنامهٔ نمونه سفارش، انتقال وجه یا برداشت ایجاد نمی‌کند و فقط داده‌ها و اشتراک‌ها را بررسی می‌کند.
+
+کنسول بازطراحی‌شده عملیات REST عمومی، REST خصوصی و WebSocket را جدا می‌کند. نماد قابل‌ویرایش، فیلدهای مخفی اعتبارنامه، نمایش جدولی پاسخ، وضعیت عملیات و لاگ زمان‌دار برای مدت درخواست و خطاهای API در دسترس است. مقدار کلیدها هیچ‌گاه داخل لاگ نوشته نمی‌شود.
 
 ## روند توسعه و انتشار
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # HitBTC.Net
 
-A C# client library for the HitBTC REST and WebSocket API. The library targets
+A C# client library for the HitBTC API v3 REST and WebSocket interfaces. The library targets
 .NET Framework 4.8 and provides typed clients for public market data, account
 operations, trading, trading history, and JSON-RPC WebSocket operations.
+
+> The client has migrated from the deprecated API v2 contract to API v3. Existing
+> applications should review the migration notes below before upgrading.
 
 > This is an unofficial client library. Test trading and withdrawal operations
 > carefully before using them with a funded account.
@@ -71,9 +74,9 @@ using Hitbtc;
 
 var api = new HitBtcRestApi();
 var symbols = await api.PublicData.GetSymbol();
-var ticker = await api.PublicData.GetTicker("BTCUSD");
+var ticker = await api.PublicData.GetTicker("BTCUSDT");
 var candles = await api.PublicData.GetCandles(
-    "BTCUSD",
+    "BTCUSDT",
     PublicEnum.EnPeriod.H4);
 ```
 
@@ -86,7 +89,7 @@ var api = new HitBtcRestApi();
 api.Authorize(apiKey, secretKey);
 
 var balances = await api.Trading.GetBalance();
-var orders = await api.Trading.GetOrders("BTCUSD");
+var orders = await api.Trading.GetOrders("BTCUSDT");
 ```
 
 Do not hard-code or commit API credentials. Load them from a secure secret store
@@ -107,8 +110,7 @@ using Hitbtc;
 
 using (var api = new HitBtcSocketApi())
 {
-    var currencies = await api.MarketData.GetCurrencies();
-    var symbol = await api.MarketData.GetSymbol("BTCUSD");
+    var subscription = await api.MarketData.SubscribeTicker("BTCUSDT");
 }
 ```
 
@@ -123,8 +125,53 @@ using (var api = new HitBtcSocketApi())
 ```
 
 The client reuses its open connection, assembles fragmented UTF-8 messages,
-serializes operations on the shared socket, and exposes cancellation through the
+uses separate public and trading v3 connections, serializes operations on each socket, and exposes cancellation through the
 `Execute` overload accepting a `CancellationToken`.
+
+API v3 no longer provides one-shot currency, symbol, or historical-trade queries
+over WebSocket. Use `HitBtcRestApi.PublicData` and `HitBtcRestApi.TradingHistory` for those
+queries. The corresponding legacy methods are retained as obsolete members and
+throw `NotSupportedException` so that migration failures are explicit.
+
+## Migrating from API v2 to API v3
+
+This version talks exclusively to REST paths under `/api/3`. Public streaming
+uses `wss://api.hitbtc.com/api/3/ws/public`, while authenticated spot commands
+use `wss://api.hitbtc.com/api/3/ws/trading`.
+
+The important contract differences are:
+
+| API v2 | API v3 |
+| --- | --- |
+| REST resources grouped under `/api/2` | Resources grouped by `public`, `spot`, and `wallet` under `/api/3` |
+| Many JSON fields and parameters used camelCase | Fields and parameters use snake_case, such as `client_order_id` and `time_in_force` |
+| Public symbol and ticker collections were arrays | Collections are objects keyed by symbol/currency; the client converts them to the existing typed lists |
+| Order-book levels were `{ price, size }` objects | Levels are compact `[price, size]` arrays; conversion is handled by the model converter |
+| One WebSocket endpoint and methods such as `subscribeTicker` | Separate public/trading endpoints and channel subscriptions such as `subscribe` with `ticker/1s` |
+| Account and trading balances used `/account` and `/trading` | Wallet operations use `/wallet`; spot balances and orders use `/spot` |
+| Transfer direction used `bankToExchange`/`exchangeToBank` | Transfers specify `source` and `destination` (`wallet` and `spot`) |
+
+The public C# method names have largely been preserved to reduce application
+changes, including the historical misspelling `PostWithraw`. New code should use
+`PostWithdraw`, which accepts decimal amounts as strings and supports v3
+`network_code`. Do not send real orders or withdrawals until the upgraded client
+has been verified with the permissions and symbols used by your application.
+
+## Running the demo application
+
+`Test/Test.csproj` is an interactive WinForms API v3 demo. Before using buttons
+that access private data, set credentials in the process environment:
+
+```powershell
+$env:HITBTC_API_KEY = "your-api-key"
+$env:HITBTC_SECRET_KEY = "your-secret-key"
+dotnet run --project Test/Test.csproj
+```
+
+The Public Test and socket MarketData buttons do not need credentials. The
+Trading, Trading History, Account, and socket Trading buttons do. The demo only
+reads public/private data or creates a subscription; it does not submit orders,
+transfers, or withdrawals.
 
 ## Development workflow
 
@@ -203,5 +250,145 @@ or overwrite a published version tag. Create a new patch version instead.
 
 ## License
 
-No license file is currently included. Add an explicit license before distributing
-the project as an open-source package.
+This project is licensed under the [MIT License](LICENSE). You may use, copy,
+modify, merge, publish, distribute, sublicense, and sell copies of the software,
+provided that the copyright and permission notices are retained. The software is
+provided without warranty.
+
+---
+
+<div dir="rtl" align="right">
+
+# HitBTC.Net — راهنمای فارسی
+
+کتابخانه‌ای برای استفاده از رابط‌های REST و WebSocket نسخه ۳ صرافی HitBTC در زبان C# است. این پروژه بر پایهٔ .NET Framework 4.8 ساخته شده و برای دریافت اطلاعات عمومی بازار، مدیریت کیف پول، معاملات اسپات و تاریخچهٔ معاملات، مدل‌ها و کلاینت‌های نوع‌دار ارائه می‌دهد.
+
+> این کتابخانه رسمی HitBTC نیست. پیش از استفاده از قابلیت‌های معامله یا برداشت روی حساب دارای موجودی، آن‌ها را با دقت بررسی کنید.
+
+## ساختار مخزن
+
+| مسیر | کاربرد |
+| --- | --- |
+| `HitBtc/` | کتابخانهٔ اصلی که فایل `Hitbtc.dll` را تولید می‌کند |
+| `HitBtc/HitBtcCategories/` | گروه‌های عملیاتی REST و WebSocket |
+| `HitBtc/HitBtcModel/` | مدل‌های درخواست و پاسخ |
+| `HitBtc.Tests/` | تست‌های خودکار و مستقل از سرویس زنده |
+| `Test/` | برنامهٔ نمایشی WinForms برای آزمایش دستی |
+| `.github/workflows/` | فرایند خودکار بیلد، تست و انتشار |
+
+پروژهٔ `Test` برنامهٔ نمونه است و جایگزین مجموعه‌تست خودکار نیست. فرایند CI فقط تست‌های `HitBtc.Tests` را اجرا می‌کند و به کلید واقعی API نیاز ندارد.
+
+## پیش‌نیازها
+
+- ویندوز و بستهٔ توسعهٔ .NET Framework 4.8
+- Visual Studio 2022 یا یک نسخهٔ سازگار از .NET SDK و NuGet CLI
+- Git برای مشارکت و ساخت نسخهٔ انتشار
+
+## بازیابی وابستگی‌ها، بیلد و تست
+
+</div>
+
+```powershell
+git clone https://github.com/iarash84/hitbtc.net.git
+cd hitbtc.net
+nuget restore Hitbtc.sln
+dotnet build Hitbtc.sln --configuration Release --no-restore
+dotnet test HitBtc.Tests/HitBtc.Tests.csproj --configuration Release --no-build --no-restore
+```
+
+<div dir="rtl" align="right">
+
+فایل DLL نسخهٔ Release در مسیر `HitBtc/bin/Release/Hitbtc.dll` ساخته می‌شود. هنگام توزیع دستی، وابستگی‌های موجود در پوشهٔ خروجی را نیز همراه آن منتشر کنید.
+
+## استفاده از REST API
+
+endpointهای عمومی به کلید API نیاز ندارند:
+
+</div>
+
+```csharp
+using Hitbtc;
+
+var api = new HitBtcRestApi();
+var symbols = await api.PublicData.GetSymbol();
+var ticker = await api.PublicData.GetTicker("BTCUSDT");
+```
+
+<div dir="rtl" align="right">
+
+برای عملیات خصوصی ابتدا کلاینت را احراز هویت کنید:
+
+</div>
+
+```csharp
+var api = new HitBtcRestApi();
+api.Authorize(apiKey, secretKey);
+
+var balances = await api.Trading.GetBalance();
+var orders = await api.Trading.GetOrders("BTCUSDT");
+```
+
+<div dir="rtl" align="right">
+
+کلیدها را داخل کد یا مخزن قرار ندهید و فقط دسترسی‌های موردنیاز برنامه را برای آن‌ها فعال کنید.
+
+## استفاده از WebSocket
+
+</div>
+
+```csharp
+using (var api = new HitBtcSocketApi())
+{
+    var subscription = await api.MarketData.SubscribeTicker("BTCUSDT");
+}
+```
+
+<div dir="rtl" align="right">
+
+نسخهٔ ۳ از اتصال‌های جداگانه برای داده‌های عمومی و عملیات معاملاتی استفاده می‌کند. درخواست‌های یک‌بارهٔ ارزها، نمادها و تاریخچهٔ معاملات دیگر از طریق WebSocket ارائه نمی‌شوند و باید از `HitBtcRestApi.PublicData` یا `HitBtcRestApi.TradingHistory` استفاده شود.
+
+## تفاوت نسخهٔ ۲ و ۳
+
+| نسخهٔ ۲ | نسخهٔ ۳ |
+| --- | --- |
+| مسیرهای REST زیر `/api/2` | مسیرهای گروه‌بندی‌شده زیر `/api/3` |
+| نام‌های camelCase | نام‌های snake_case مانند `client_order_id` |
+| لیست آرایه‌ای symbol و ticker | آبجکت‌های کلیدگذاری‌شده با نام نماد یا ارز |
+| یک endpoint برای WebSocket | endpointهای جداگانهٔ Public و Trading |
+| متدهایی مانند `subscribeTicker` | اشتراک کانال با `subscribe` و `ticker/1s` |
+| حساب‌های `/account` و `/trading` | گروه‌های `/wallet` و `/spot` |
+
+نام بیشتر متدهای عمومی C# برای کاهش تغییرات مصرف‌کنندگان حفظ شده است. برای برداشت در کد جدید از `PostWithdraw` استفاده کنید؛ متد قدیمی `PostWithraw` فقط برای سازگاری باقی مانده است.
+
+## اجرای برنامهٔ نمونه
+
+پیش از استفاده از دکمه‌های خصوصی برنامهٔ WinForms، متغیرهای محیطی زیر را تنظیم کنید:
+
+</div>
+
+```powershell
+$env:HITBTC_API_KEY = "your-api-key"
+$env:HITBTC_SECRET_KEY = "your-secret-key"
+dotnet run --project Test/Test.csproj
+```
+
+<div dir="rtl" align="right">
+
+برنامهٔ نمونه سفارش، انتقال وجه یا برداشت ایجاد نمی‌کند و فقط داده‌ها و اشتراک‌ها را بررسی می‌کند.
+
+## روند توسعه و انتشار
+
+شاخهٔ `master` محافظت‌شده است. تغییرات را در یک شاخهٔ feature انجام دهید، تست‌ها را اجرا کنید و سپس Pull Request بسازید. برای انتشار نسخهٔ جدید، پس از ادغام تغییرات و موفقیت CI یک تگ معنایی مانند `v1.1.0` ایجاد و push کنید. workflow فایل Release را می‌سازد و ZIP خروجی را به GitHub Release متصل می‌کند.
+
+## مشارکت و امنیت
+
+- تست‌ها باید قطعی و مستقل از سرویس زنده باشند.
+- هیچ کلید API، رمز، شناسهٔ حساب یا اطلاعات مالی را commit نکنید.
+- برای رفع باگ، تست بازگشتی اضافه کنید.
+- تغییرات هر Pull Request را متمرکز و محدود نگه دارید.
+
+## مجوز
+
+این پروژه تحت [مجوز MIT](LICENSE) منتشر شده است. استفاده، کپی، تغییر، ادغام، انتشار، توزیع و فروش نرم‌افزار با حفظ اعلان حق نشر و متن مجوز مجاز است. نرم‌افزار بدون هیچ‌گونه ضمانت ارائه می‌شود.
+
+</div>

--- a/README.md
+++ b/README.md
@@ -1,36 +1,207 @@
-# hitbtc
-HitBTC Websocket API 2.0 Client written in C#.\
-A full-featured .NET **[Hitbtc API](https://api.hitbtc.com)** designed for ease of use.\
-Compatible with **.NET 4.5.1, .NET 4.5.2, .NET 4.6.1, .NET STANDARD 2.0**
+# HitBTC.Net
 
+A C# client library for the HitBTC REST and WebSocket API. The library targets
+.NET Framework 4.8 and provides typed clients for public market data, account
+operations, trading, trading history, and JSON-RPC WebSocket operations.
 
-## Getting Started
+> This is an unofficial client library. Test trading and withdrawal operations
+> carefully before using them with a funded account.
 
-Go to https://hitbtc.com/settings/api-keys and create your api keys
+## Repository structure
 
-## Quick Examples
+| Path | Purpose |
+| --- | --- |
+| `HitBtc/` | The .NET Framework 4.8 class library that produces `Hitbtc.dll` |
+| `HitBtc/HitBtcCategories/` | REST and WebSocket API operation groups |
+| `HitBtc/HitBtcModel/` | Request and response models |
+| `HitBtc.Tests/` | Deterministic xUnit tests that do not use the live HitBTC service |
+| `Test/` | A WinForms demo application for optional manual testing |
+| `.github/workflows/` | Automated build, test, artifact, and release workflow |
 
-```C#
-using Hitbtc;
+The `Test` project is a demo application, not the automated test suite. CI uses
+`HitBtc.Tests` and never requires real API credentials.
 
-var hitBtcRestApi = new HitBtcRestApi();
-if (!hitBtcRestApi.IsAuthorized)
-	hitBtcRestApi.Authorize(ApiKey, SecretKey);
+## Requirements
 
-//var response = await hitBtcRestApi.Trading.GetBalance();
-//var response = await hitBtcRestApi.Trading.GetFee("BTCUSD");
-var response = await hitBtcRestApi.Trading.GetOrders("BTCUSD");
+- Windows with the .NET Framework 4.8 Developer Pack
+- Visual Studio 2022, or a compatible .NET SDK and NuGet CLI
+- Git, when contributing or creating a release
+
+## Restore, build, and test
+
+Clone the repository and restore its dependencies:
+
+```powershell
+git clone https://github.com/iarash84/hitbtc.net.git
+cd hitbtc.net
+nuget restore Hitbtc.sln
 ```
 
-#### Web Socket
-Get real-time aggregate trades.
+Build the complete solution:
 
-```C#
+```powershell
+dotnet build Hitbtc.sln --configuration Release --no-restore
+```
+
+Run the automated tests:
+
+```powershell
+dotnet test HitBtc.Tests/HitBtc.Tests.csproj `
+  --configuration Release `
+  --no-build `
+  --no-restore
+```
+
+The Release library is generated at:
+
+```text
+HitBtc/bin/Release/Hitbtc.dll
+```
+
+The DLL depends on the other assemblies copied into the same output directory.
+When distributing the library manually, ship all required DLL files from that
+directory rather than `Hitbtc.dll` alone.
+
+## Using the REST API
+
+Public endpoints do not require credentials:
+
+```csharp
 using Hitbtc;
 
-var hitBtcSocketApi = new HitBtcSocketApi();
-//var response = await hitBtcSocketApi.MarketData.GetCurrency("ETH");
-//var response = await hitBtcSocketApi.MarketData.GetCurrencies();
-var response = await hitBtcSocketApi.MarketData.UnsubscribeCandles("BTCUSD");
-
+var api = new HitBtcRestApi();
+var symbols = await api.PublicData.GetSymbol();
+var ticker = await api.PublicData.GetTicker("BTCUSD");
+var candles = await api.PublicData.GetCandles(
+    "BTCUSD",
+    PublicEnum.EnPeriod.H4);
 ```
+
+Account and trading endpoints require authorization:
+
+```csharp
+using Hitbtc;
+
+var api = new HitBtcRestApi();
+api.Authorize(apiKey, secretKey);
+
+var balances = await api.Trading.GetBalance();
+var orders = await api.Trading.GetOrders("BTCUSD");
+```
+
+Do not hard-code or commit API credentials. Load them from a secure secret store
+or environment variables. Only grant the API key permissions required by your
+application.
+
+REST requests fail with an exception when authorization is missing, the server
+returns an unsuccessful HTTP status, or a response contains malformed JSON.
+These errors are not converted into empty response models.
+
+## Using the WebSocket API
+
+`HitBtcSocketApi` owns a WebSocket connection and implements `IDisposable`.
+Reuse one instance for related operations and dispose it when finished:
+
+```csharp
+using Hitbtc;
+
+using (var api = new HitBtcSocketApi())
+{
+    var currencies = await api.MarketData.GetCurrencies();
+    var symbol = await api.MarketData.GetSymbol("BTCUSD");
+}
+```
+
+Authenticated WebSocket operations require credentials:
+
+```csharp
+using (var api = new HitBtcSocketApi())
+{
+    api.Authorize(apiKey, secretKey);
+    var balances = await api.Trading.GetTradingBalance();
+}
+```
+
+The client reuses its open connection, assembles fragmented UTF-8 messages,
+serializes operations on the shared socket, and exposes cancellation through the
+`Execute` overload accepting a `CancellationToken`.
+
+## Development workflow
+
+The `master` branch is protected. Make each logical change on a feature branch
+and merge it through a pull request:
+
+```powershell
+git switch master
+git pull origin master
+git switch -c feature/short-description
+
+# Edit files, then commit the related changes.
+git add .
+git commit -m "feat: describe the change"
+git push --set-upstream origin feature/short-description
+```
+
+Open a pull request targeting `master`. The automated workflow restores
+dependencies, builds the Release configuration, and runs the test suite. Merge
+only after the required checks pass.
+
+## Continuous integration artifacts
+
+Every push runs `.github/workflows/build-test-release.yml`. A successful run:
+
+1. restores NuGet dependencies;
+2. builds the solution in Release mode;
+3. runs the automated tests;
+4. uploads `Hitbtc.dll` and its runtime dependencies as a GitHub Actions artifact.
+
+The artifact name contains the commit SHA and is retained for 30 days. Artifacts
+from ordinary pushes are build outputs; they are not permanent GitHub Releases.
+
+## Creating a new release
+
+Releases use semantic version tags such as `v1.1.0`:
+
+- increment the major version for breaking public API changes;
+- increment the minor version for backward-compatible features;
+- increment the patch version for backward-compatible fixes.
+
+Before releasing:
+
+1. ensure the intended changes have been merged into `master`;
+2. confirm the GitHub Actions checks are successful;
+3. update assembly/package version metadata when the version changes;
+4. build and test the exact commit locally.
+
+Then synchronize `master`, create an annotated tag, and push the tag:
+
+```powershell
+git switch master
+git pull --ff-only origin master
+
+git tag -a v1.1.0 -m "Release v1.1.0"
+git push origin v1.1.0
+```
+
+Pushing the tag triggers the workflow. After the build and tests pass, it:
+
+1. collects the Release DLL files;
+2. creates `Hitbtc-v1.1.0.zip`;
+3. creates the GitHub Release from the tag;
+4. attaches the ZIP file and generated release notes.
+
+If the workflow fails, fix the problem through another pull request. Do not move
+or overwrite a published version tag. Create a new patch version instead.
+
+## Contributing
+
+- Keep normal tests deterministic and independent of live exchange connectivity.
+- Never commit API keys, secret keys, account identifiers, or funded-account data.
+- Add regression tests for bug fixes.
+- Preserve the public API unless a breaking change is planned for a major release.
+- Keep pull requests focused on one logical change.
+
+## License
+
+No license file is currently included. Add an explicit license before distributing
+the project as an open-source package.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ application.
 REST requests fail with an exception when authorization is missing, the server
 returns an unsuccessful HTTP status, or a response contains malformed JSON.
 These errors are not converted into empty response models.
+HTTP/API failures throw `HitBtcApiException`, which exposes `StatusCode` and the
+exchange `ApiErrorCode` when available.
 
 ## Using the WebSocket API
 
@@ -132,6 +134,11 @@ API v3 no longer provides one-shot currency, symbol, or historical-trade queries
 over WebSocket. Use `HitBtcRestApi.PublicData` and `HitBtcRestApi.TradingHistory` for those
 queries. The corresponding legacy methods are retained as obsolete members and
 throw `NotSupportedException` so that migration failures are explicit.
+Malformed messages, exchange errors, and mismatched response IDs throw
+`HitBtcWebSocketException`. The current high-level subscription methods return
+the subscription acknowledgement; applications that need a continuous event
+stream should use the low-level protocol carefully until a notification API is
+added.
 
 ## Migrating from API v2 to API v3
 
@@ -332,6 +339,8 @@ var orders = await api.Trading.GetOrders("BTCUSDT");
 
 کلیدها را داخل کد یا مخزن قرار ندهید و فقط دسترسی‌های موردنیاز برنامه را برای آن‌ها فعال کنید.
 
+خطاهای HTTP و خطاهای API با `HitBtcApiException` گزارش می‌شوند. این exception در صورت موجود بودن، وضعیت HTTP و کد خطای صرافی را نیز ارائه می‌دهد و پاسخ نامعتبر را به مدل خالی تبدیل نمی‌کند.
+
 ## استفاده از WebSocket
 
 </div>
@@ -346,6 +355,8 @@ using (var api = new HitBtcSocketApi())
 <div dir="rtl" align="right">
 
 نسخهٔ ۳ از اتصال‌های جداگانه برای داده‌های عمومی و عملیات معاملاتی استفاده می‌کند. درخواست‌های یک‌بارهٔ ارزها، نمادها و تاریخچهٔ معاملات دیگر از طریق WebSocket ارائه نمی‌شوند و باید از `HitBtcRestApi.PublicData` یا `HitBtcRestApi.TradingHistory` استفاده شود.
+
+پاسخ JSON نامعتبر، خطای سرور یا شناسهٔ نامنطبق با `HitBtcWebSocketException` گزارش می‌شود. متدهای فعلی اشتراک فقط تأیید اشتراک را برمی‌گردانند و هنوز API سطح‌بالایی برای دریافت پیوستهٔ notificationها ارائه نشده است.
 
 ## تفاوت نسخهٔ ۲ و ۳
 

--- a/Test/frmTest.Designer.cs
+++ b/Test/frmTest.Designer.cs
@@ -1,142 +1,375 @@
-﻿namespace Test
+namespace Test
 {
     partial class frmTest
     {
-        /// <summary>
-        /// Required designer variable.
-        /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
+            if (disposing && components != null) components.Dispose();
             base.Dispose(disposing);
         }
 
-        #region Windows Form Designer generated code
-
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
         private void InitializeComponent()
         {
-            this.btnPublicTest = new System.Windows.Forms.Button();
-            this.btnTradingTest = new System.Windows.Forms.Button();
+            this.headerPanel = new System.Windows.Forms.Panel();
+            this.lblSubtitle = new System.Windows.Forms.Label();
+            this.lblTitle = new System.Windows.Forms.Label();
+            this.settingsPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.lblSymbol = new System.Windows.Forms.Label();
+            this.txtSymbol = new System.Windows.Forms.TextBox();
+            this.lblApiKey = new System.Windows.Forms.Label();
+            this.txtApiKey = new System.Windows.Forms.TextBox();
+            this.lblSecret = new System.Windows.Forms.Label();
+            this.txtSecret = new System.Windows.Forms.TextBox();
+            this.chkShowSecret = new System.Windows.Forms.CheckBox();
+            this.btnLoadEnvironment = new System.Windows.Forms.Button();
+            this.actionsPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.grpPublicRest = new System.Windows.Forms.GroupBox();
+            this.publicButtons = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnTicker = new System.Windows.Forms.Button();
+            this.btnSymbols = new System.Windows.Forms.Button();
+            this.btnCurrencies = new System.Windows.Forms.Button();
+            this.btnOrderBook = new System.Windows.Forms.Button();
+            this.btnCandles = new System.Windows.Forms.Button();
+            this.grpPrivateRest = new System.Windows.Forms.GroupBox();
+            this.privateButtons = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnSpotBalance = new System.Windows.Forms.Button();
+            this.btnActiveOrders = new System.Windows.Forms.Button();
             this.btnTradingHistory = new System.Windows.Forms.Button();
-            this.btnAccount = new System.Windows.Forms.Button();
-            this.btnMarketData = new System.Windows.Forms.Button();
-            this.btnSocketTrading = new System.Windows.Forms.Button();
-            this.gridviewReponse = new System.Windows.Forms.DataGridView();
-            ((System.ComponentModel.ISupportInitialize)(this.gridviewReponse)).BeginInit();
+            this.btnWalletBalance = new System.Windows.Forms.Button();
+            this.grpWebSocket = new System.Windows.Forms.GroupBox();
+            this.socketButtons = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnSubscribeTicker = new System.Windows.Forms.Button();
+            this.btnSocketBalance = new System.Windows.Forms.Button();
+            this.contentSplit = new System.Windows.Forms.SplitContainer();
+            this.resultPanel = new System.Windows.Forms.Panel();
+            this.gridResults = new System.Windows.Forms.DataGridView();
+            this.resultHeader = new System.Windows.Forms.Panel();
+            this.lblResultCount = new System.Windows.Forms.Label();
+            this.lblResults = new System.Windows.Forms.Label();
+            this.logPanel = new System.Windows.Forms.Panel();
+            this.txtLog = new System.Windows.Forms.RichTextBox();
+            this.logHeader = new System.Windows.Forms.Panel();
+            this.btnClearLog = new System.Windows.Forms.Button();
+            this.lblLog = new System.Windows.Forms.Label();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
+            this.lblSpacer = new System.Windows.Forms.ToolStripStatusLabel();
+            this.lblVersion = new System.Windows.Forms.ToolStripStatusLabel();
+            this.headerPanel.SuspendLayout();
+            this.settingsPanel.SuspendLayout();
+            this.actionsPanel.SuspendLayout();
+            this.grpPublicRest.SuspendLayout();
+            this.publicButtons.SuspendLayout();
+            this.grpPrivateRest.SuspendLayout();
+            this.privateButtons.SuspendLayout();
+            this.grpWebSocket.SuspendLayout();
+            this.socketButtons.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.contentSplit)).BeginInit();
+            this.contentSplit.Panel1.SuspendLayout();
+            this.contentSplit.Panel2.SuspendLayout();
+            this.contentSplit.SuspendLayout();
+            this.resultPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.gridResults)).BeginInit();
+            this.resultHeader.SuspendLayout();
+            this.logPanel.SuspendLayout();
+            this.logHeader.SuspendLayout();
+            this.statusStrip.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // btnPublicTest
-            // 
-            this.btnPublicTest.Location = new System.Drawing.Point(12, 22);
-            this.btnPublicTest.Name = "btnPublicTest";
-            this.btnPublicTest.Size = new System.Drawing.Size(75, 23);
-            this.btnPublicTest.TabIndex = 0;
-            this.btnPublicTest.Text = "Public Test";
-            this.btnPublicTest.UseVisualStyleBackColor = true;
-            this.btnPublicTest.Click += new System.EventHandler(this.btnPublicTest_Click);
-            // 
-            // btnTradingTest
-            // 
-            this.btnTradingTest.Location = new System.Drawing.Point(93, 22);
-            this.btnTradingTest.Name = "btnTradingTest";
-            this.btnTradingTest.Size = new System.Drawing.Size(75, 23);
-            this.btnTradingTest.TabIndex = 2;
-            this.btnTradingTest.Text = "Trading Test";
-            this.btnTradingTest.UseVisualStyleBackColor = true;
-            this.btnTradingTest.Click += new System.EventHandler(this.btnTradingTest_Click);
-            // 
-            // btnTradingHistory
-            // 
-            this.btnTradingHistory.Location = new System.Drawing.Point(174, 22);
-            this.btnTradingHistory.Name = "btnTradingHistory";
-            this.btnTradingHistory.Size = new System.Drawing.Size(106, 23);
-            this.btnTradingHistory.TabIndex = 3;
-            this.btnTradingHistory.Text = "Trading History";
-            this.btnTradingHistory.UseVisualStyleBackColor = true;
-            this.btnTradingHistory.Click += new System.EventHandler(this.btnTradingHistory_Click);
-            // 
-            // btnAccount
-            // 
-            this.btnAccount.Location = new System.Drawing.Point(286, 22);
-            this.btnAccount.Name = "btnAccount";
-            this.btnAccount.Size = new System.Drawing.Size(106, 23);
-            this.btnAccount.TabIndex = 4;
-            this.btnAccount.Text = "Account";
-            this.btnAccount.UseVisualStyleBackColor = true;
-            this.btnAccount.Click += new System.EventHandler(this.btnAccount_Click);
-            // 
-            // btnMarketData
-            // 
-            this.btnMarketData.Location = new System.Drawing.Point(12, 51);
-            this.btnMarketData.Name = "btnMarketData";
-            this.btnMarketData.Size = new System.Drawing.Size(156, 23);
-            this.btnMarketData.TabIndex = 5;
-            this.btnMarketData.Text = "socket MarketData";
-            this.btnMarketData.UseVisualStyleBackColor = true;
-            this.btnMarketData.Click += new System.EventHandler(this.btnMarketData_Click);
-            // 
-            // btnSocketTrading
-            // 
-            this.btnSocketTrading.Location = new System.Drawing.Point(174, 51);
-            this.btnSocketTrading.Name = "btnSocketTrading";
-            this.btnSocketTrading.Size = new System.Drawing.Size(156, 23);
-            this.btnSocketTrading.TabIndex = 6;
-            this.btnSocketTrading.Text = "socket Trading";
-            this.btnSocketTrading.UseVisualStyleBackColor = true;
-            this.btnSocketTrading.Click += new System.EventHandler(this.btnSocketTrading_Click);
-            // 
-            // gridviewReponse
-            // 
-            this.gridviewReponse.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.gridviewReponse.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.gridviewReponse.Location = new System.Drawing.Point(12, 80);
-            this.gridviewReponse.Name = "gridviewReponse";
-            this.gridviewReponse.Size = new System.Drawing.Size(540, 175);
-            this.gridviewReponse.TabIndex = 7;
-            // 
-            // frmTest
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            // headerPanel
+            this.headerPanel.BackColor = System.Drawing.Color.FromArgb(24, 35, 54);
+            this.headerPanel.Controls.Add(this.lblSubtitle);
+            this.headerPanel.Controls.Add(this.lblTitle);
+            this.headerPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.headerPanel.Height = 78;
+            // lblTitle
+            this.lblTitle.AutoSize = true;
+            this.lblTitle.Font = new System.Drawing.Font("Segoe UI Semibold", 20F);
+            this.lblTitle.ForeColor = System.Drawing.Color.White;
+            this.lblTitle.Location = new System.Drawing.Point(20, 10);
+            this.lblTitle.Text = "HitBTC.Net  •  API v3 Test Console";
+            // lblSubtitle
+            this.lblSubtitle.AutoSize = true;
+            this.lblSubtitle.Font = new System.Drawing.Font("Segoe UI", 9.5F);
+            this.lblSubtitle.ForeColor = System.Drawing.Color.FromArgb(176, 190, 210);
+            this.lblSubtitle.Location = new System.Drawing.Point(23, 49);
+            this.lblSubtitle.Text = "Read-only manual verification for REST and WebSocket endpoints  |  ابزار تست دستی و فقط‌خواندنی";
+            // settingsPanel
+            this.settingsPanel.BackColor = System.Drawing.Color.White;
+            this.settingsPanel.ColumnCount = 8;
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45F));
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45F));
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.settingsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.settingsPanel.Controls.Add(this.lblSymbol, 0, 0);
+            this.settingsPanel.Controls.Add(this.txtSymbol, 1, 0);
+            this.settingsPanel.Controls.Add(this.lblApiKey, 2, 0);
+            this.settingsPanel.Controls.Add(this.txtApiKey, 3, 0);
+            this.settingsPanel.Controls.Add(this.lblSecret, 4, 0);
+            this.settingsPanel.Controls.Add(this.txtSecret, 5, 0);
+            this.settingsPanel.Controls.Add(this.chkShowSecret, 6, 0);
+            this.settingsPanel.Controls.Add(this.btnLoadEnvironment, 7, 0);
+            this.settingsPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.settingsPanel.Height = 58;
+            this.settingsPanel.Padding = new System.Windows.Forms.Padding(16, 12, 16, 8);
+            // labels and inputs
+            this.lblSymbol.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblSymbol.AutoSize = true;
+            this.lblSymbol.Text = "Symbol";
+            this.lblSymbol.Margin = new System.Windows.Forms.Padding(4, 0, 8, 0);
+            this.txtSymbol.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            this.txtSymbol.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
+            this.txtSymbol.Text = "BTCUSDT";
+            this.lblApiKey.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblApiKey.AutoSize = true;
+            this.lblApiKey.Text = "API key";
+            this.lblApiKey.Margin = new System.Windows.Forms.Padding(14, 0, 8, 0);
+            this.txtApiKey.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            this.txtApiKey.UseSystemPasswordChar = true;
+            this.lblSecret.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblSecret.AutoSize = true;
+            this.lblSecret.Text = "Secret";
+            this.lblSecret.Margin = new System.Windows.Forms.Padding(14, 0, 8, 0);
+            this.txtSecret.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            this.txtSecret.UseSystemPasswordChar = true;
+            this.chkShowSecret.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkShowSecret.AutoSize = true;
+            this.chkShowSecret.Text = "Show";
+            this.chkShowSecret.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
+            this.chkShowSecret.CheckedChanged += new System.EventHandler(this.chkShowSecret_CheckedChanged);
+            this.btnLoadEnvironment.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.btnLoadEnvironment.AutoSize = true;
+            this.btnLoadEnvironment.Text = "Load environment";
+            this.btnLoadEnvironment.Click += new System.EventHandler(this.btnLoadEnvironment_Click);
+            // actionsPanel
+            this.actionsPanel.BackColor = System.Drawing.Color.FromArgb(244, 247, 251);
+            this.actionsPanel.ColumnCount = 3;
+            this.actionsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 40F));
+            this.actionsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 35F));
+            this.actionsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.actionsPanel.Controls.Add(this.grpPublicRest, 0, 0);
+            this.actionsPanel.Controls.Add(this.grpPrivateRest, 1, 0);
+            this.actionsPanel.Controls.Add(this.grpWebSocket, 2, 0);
+            this.actionsPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.actionsPanel.Height = 126;
+            this.actionsPanel.Padding = new System.Windows.Forms.Padding(12, 4, 12, 8);
+            // groups
+            this.grpPublicRest.Controls.Add(this.publicButtons);
+            this.grpPublicRest.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpPublicRest.Text = "Public REST  •  بدون کلید";
+            this.grpPublicRest.Margin = new System.Windows.Forms.Padding(4);
+            this.publicButtons.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.publicButtons.Padding = new System.Windows.Forms.Padding(5, 8, 5, 5);
+            this.publicButtons.Controls.Add(this.btnTicker);
+            this.publicButtons.Controls.Add(this.btnSymbols);
+            this.publicButtons.Controls.Add(this.btnCurrencies);
+            this.publicButtons.Controls.Add(this.btnOrderBook);
+            this.publicButtons.Controls.Add(this.btnCandles);
+            this.grpPrivateRest.Controls.Add(this.privateButtons);
+            this.grpPrivateRest.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpPrivateRest.Text = "Private REST  •  نیازمند کلید";
+            this.grpPrivateRest.Margin = new System.Windows.Forms.Padding(4);
+            this.privateButtons.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.privateButtons.Padding = new System.Windows.Forms.Padding(5, 8, 5, 5);
+            this.privateButtons.Controls.Add(this.btnSpotBalance);
+            this.privateButtons.Controls.Add(this.btnActiveOrders);
+            this.privateButtons.Controls.Add(this.btnTradingHistory);
+            this.privateButtons.Controls.Add(this.btnWalletBalance);
+            this.grpWebSocket.Controls.Add(this.socketButtons);
+            this.grpWebSocket.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpWebSocket.Text = "WebSocket v3";
+            this.grpWebSocket.Margin = new System.Windows.Forms.Padding(4);
+            this.socketButtons.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.socketButtons.Padding = new System.Windows.Forms.Padding(5, 8, 5, 5);
+            this.socketButtons.Controls.Add(this.btnSubscribeTicker);
+            this.socketButtons.Controls.Add(this.btnSocketBalance);
+            // buttons
+            ConfigureActionButton(this.btnTicker, "Ticker", this.btnTicker_Click);
+            ConfigureActionButton(this.btnSymbols, "Symbols", this.btnSymbols_Click);
+            ConfigureActionButton(this.btnCurrencies, "Currencies", this.btnCurrencies_Click);
+            ConfigureActionButton(this.btnOrderBook, "Order book", this.btnOrderBook_Click);
+            ConfigureActionButton(this.btnCandles, "Candles", this.btnCandles_Click);
+            ConfigureActionButton(this.btnSpotBalance, "Spot balance", this.btnSpotBalance_Click);
+            ConfigureActionButton(this.btnActiveOrders, "Active orders", this.btnActiveOrders_Click);
+            ConfigureActionButton(this.btnTradingHistory, "Trade history", this.btnTradingHistory_Click);
+            ConfigureActionButton(this.btnWalletBalance, "Wallet balance", this.btnWalletBalance_Click);
+            ConfigureActionButton(this.btnSubscribeTicker, "Subscribe ticker", this.btnSubscribeTicker_Click);
+            ConfigureActionButton(this.btnSocketBalance, "Trading balance", this.btnSocketBalance_Click);
+            // contentSplit
+            this.contentSplit.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.contentSplit.Location = new System.Drawing.Point(0, 262);
+            this.contentSplit.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.contentSplit.Panel1.Controls.Add(this.resultPanel);
+            this.contentSplit.Panel2.Controls.Add(this.logPanel);
+            this.contentSplit.SplitterDistance = 285;
+            this.contentSplit.SplitterWidth = 6;
+            // results
+            this.resultPanel.Controls.Add(this.gridResults);
+            this.resultPanel.Controls.Add(this.resultHeader);
+            this.resultPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.gridResults.AllowUserToAddRows = false;
+            this.gridResults.AllowUserToDeleteRows = false;
+            this.gridResults.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.DisplayedCells;
+            this.gridResults.BackgroundColor = System.Drawing.Color.White;
+            this.gridResults.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.gridResults.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.gridResults.ReadOnly = true;
+            this.gridResults.RowHeadersVisible = false;
+            this.gridResults.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.resultHeader.BackColor = System.Drawing.Color.White;
+            this.resultHeader.Controls.Add(this.lblResultCount);
+            this.resultHeader.Controls.Add(this.lblResults);
+            this.resultHeader.Dock = System.Windows.Forms.DockStyle.Top;
+            this.resultHeader.Height = 38;
+            this.lblResults.AutoSize = true;
+            this.lblResults.Font = new System.Drawing.Font("Segoe UI Semibold", 11F);
+            this.lblResults.Location = new System.Drawing.Point(14, 9);
+            this.lblResults.Text = "Results  •  نتایج";
+            this.lblResultCount.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            this.lblResultCount.AutoSize = true;
+            this.lblResultCount.ForeColor = System.Drawing.Color.DimGray;
+            this.lblResultCount.Location = new System.Drawing.Point(1090, 12);
+            this.lblResultCount.Text = "0 rows";
+            // log
+            this.logPanel.Controls.Add(this.txtLog);
+            this.logPanel.Controls.Add(this.logHeader);
+            this.logPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtLog.BackColor = System.Drawing.Color.FromArgb(17, 24, 39);
+            this.txtLog.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.txtLog.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtLog.Font = new System.Drawing.Font("Consolas", 9.5F);
+            this.txtLog.ForeColor = System.Drawing.Color.FromArgb(209, 213, 219);
+            this.txtLog.ReadOnly = true;
+            this.txtLog.WordWrap = false;
+            this.logHeader.BackColor = System.Drawing.Color.FromArgb(31, 41, 55);
+            this.logHeader.Controls.Add(this.btnClearLog);
+            this.logHeader.Controls.Add(this.lblLog);
+            this.logHeader.Dock = System.Windows.Forms.DockStyle.Top;
+            this.logHeader.Height = 36;
+            this.lblLog.AutoSize = true;
+            this.lblLog.Font = new System.Drawing.Font("Segoe UI Semibold", 10F);
+            this.lblLog.ForeColor = System.Drawing.Color.White;
+            this.lblLog.Location = new System.Drawing.Point(13, 8);
+            this.lblLog.Text = "Activity log  •  گزارش رویدادها";
+            this.btnClearLog.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            this.btnClearLog.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearLog.ForeColor = System.Drawing.Color.White;
+            this.btnClearLog.Location = new System.Drawing.Point(1094, 5);
+            this.btnClearLog.Size = new System.Drawing.Size(72, 26);
+            this.btnClearLog.Text = "Clear";
+            this.btnClearLog.Click += new System.EventHandler(this.btnClearLog_Click);
+            // status
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { this.lblStatus, this.lblSpacer, this.lblVersion });
+            this.statusStrip.SizingGrip = false;
+            this.lblStatus.Text = "Ready";
+            this.lblSpacer.Spring = true;
+            this.lblVersion.Text = "HitBTC API v3  |  Read-only console";
+            // form
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(564, 267);
-            this.Controls.Add(this.gridviewReponse);
-            this.Controls.Add(this.btnSocketTrading);
-            this.Controls.Add(this.btnMarketData);
-            this.Controls.Add(this.btnAccount);
-            this.Controls.Add(this.btnTradingHistory);
-            this.Controls.Add(this.btnTradingTest);
-            this.Controls.Add(this.btnPublicTest);
+            this.BackColor = System.Drawing.Color.FromArgb(244, 247, 251);
+            this.ClientSize = new System.Drawing.Size(1184, 761);
+            this.Controls.Add(this.contentSplit);
+            this.Controls.Add(this.actionsPanel);
+            this.Controls.Add(this.settingsPanel);
+            this.Controls.Add(this.headerPanel);
+            this.Controls.Add(this.statusStrip);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.MinimumSize = new System.Drawing.Size(980, 650);
             this.Name = "frmTest";
-            this.Text = "Test From";
-            ((System.ComponentModel.ISupportInitialize)(this.gridviewReponse)).EndInit();
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "HitBTC.Net API v3 Test Console";
+            this.Load += new System.EventHandler(this.frmTest_Load);
+            this.headerPanel.ResumeLayout(false);
+            this.headerPanel.PerformLayout();
+            this.settingsPanel.ResumeLayout(false);
+            this.settingsPanel.PerformLayout();
+            this.actionsPanel.ResumeLayout(false);
+            this.grpPublicRest.ResumeLayout(false);
+            this.publicButtons.ResumeLayout(false);
+            this.grpPrivateRest.ResumeLayout(false);
+            this.privateButtons.ResumeLayout(false);
+            this.grpWebSocket.ResumeLayout(false);
+            this.socketButtons.ResumeLayout(false);
+            this.contentSplit.Panel1.ResumeLayout(false);
+            this.contentSplit.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.contentSplit)).EndInit();
+            this.contentSplit.ResumeLayout(false);
+            this.resultPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.gridResults)).EndInit();
+            this.resultHeader.ResumeLayout(false);
+            this.resultHeader.PerformLayout();
+            this.logPanel.ResumeLayout(false);
+            this.logHeader.ResumeLayout(false);
+            this.logHeader.PerformLayout();
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
             this.ResumeLayout(false);
-
+            this.PerformLayout();
         }
 
-        #endregion
+        private static void ConfigureActionButton(System.Windows.Forms.Button button, string text,
+            System.EventHandler handler)
+        {
+            button.AutoSize = true;
+            button.BackColor = System.Drawing.Color.White;
+            button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            button.Margin = new System.Windows.Forms.Padding(3);
+            button.Padding = new System.Windows.Forms.Padding(5, 2, 5, 2);
+            button.Text = text;
+            button.UseVisualStyleBackColor = false;
+            button.Click += handler;
+        }
 
-        private System.Windows.Forms.Button btnPublicTest;
-        private System.Windows.Forms.Button btnTradingTest;
+        private System.Windows.Forms.Panel headerPanel;
+        private System.Windows.Forms.Label lblTitle;
+        private System.Windows.Forms.Label lblSubtitle;
+        private System.Windows.Forms.TableLayoutPanel settingsPanel;
+        private System.Windows.Forms.Label lblSymbol;
+        private System.Windows.Forms.TextBox txtSymbol;
+        private System.Windows.Forms.Label lblApiKey;
+        private System.Windows.Forms.TextBox txtApiKey;
+        private System.Windows.Forms.Label lblSecret;
+        private System.Windows.Forms.TextBox txtSecret;
+        private System.Windows.Forms.CheckBox chkShowSecret;
+        private System.Windows.Forms.Button btnLoadEnvironment;
+        private System.Windows.Forms.TableLayoutPanel actionsPanel;
+        private System.Windows.Forms.GroupBox grpPublicRest;
+        private System.Windows.Forms.FlowLayoutPanel publicButtons;
+        private System.Windows.Forms.Button btnTicker;
+        private System.Windows.Forms.Button btnSymbols;
+        private System.Windows.Forms.Button btnCurrencies;
+        private System.Windows.Forms.Button btnOrderBook;
+        private System.Windows.Forms.Button btnCandles;
+        private System.Windows.Forms.GroupBox grpPrivateRest;
+        private System.Windows.Forms.FlowLayoutPanel privateButtons;
+        private System.Windows.Forms.Button btnSpotBalance;
+        private System.Windows.Forms.Button btnActiveOrders;
         private System.Windows.Forms.Button btnTradingHistory;
-        private System.Windows.Forms.Button btnAccount;
-        private System.Windows.Forms.Button btnMarketData;
-        private System.Windows.Forms.Button btnSocketTrading;
-        private System.Windows.Forms.DataGridView gridviewReponse;
+        private System.Windows.Forms.Button btnWalletBalance;
+        private System.Windows.Forms.GroupBox grpWebSocket;
+        private System.Windows.Forms.FlowLayoutPanel socketButtons;
+        private System.Windows.Forms.Button btnSubscribeTicker;
+        private System.Windows.Forms.Button btnSocketBalance;
+        private System.Windows.Forms.SplitContainer contentSplit;
+        private System.Windows.Forms.Panel resultPanel;
+        private System.Windows.Forms.DataGridView gridResults;
+        private System.Windows.Forms.Panel resultHeader;
+        private System.Windows.Forms.Label lblResults;
+        private System.Windows.Forms.Label lblResultCount;
+        private System.Windows.Forms.Panel logPanel;
+        private System.Windows.Forms.RichTextBox txtLog;
+        private System.Windows.Forms.Panel logHeader;
+        private System.Windows.Forms.Label lblLog;
+        private System.Windows.Forms.Button btnClearLog;
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatus;
+        private System.Windows.Forms.ToolStripStatusLabel lblSpacer;
+        private System.Windows.Forms.ToolStripStatusLabel lblVersion;
     }
 }
-

--- a/Test/frmTest.Designer.cs
+++ b/Test/frmTest.Designer.cs
@@ -66,6 +66,7 @@
             this.btnTradingHistory.TabIndex = 3;
             this.btnTradingHistory.Text = "Trading History";
             this.btnTradingHistory.UseVisualStyleBackColor = true;
+            this.btnTradingHistory.Click += new System.EventHandler(this.btnTradingHistory_Click);
             // 
             // btnAccount
             // 
@@ -73,7 +74,7 @@
             this.btnAccount.Name = "btnAccount";
             this.btnAccount.Size = new System.Drawing.Size(106, 23);
             this.btnAccount.TabIndex = 4;
-            this.btnAccount.Text = "Acount";
+            this.btnAccount.Text = "Account";
             this.btnAccount.UseVisualStyleBackColor = true;
             this.btnAccount.Click += new System.EventHandler(this.btnAccount_Click);
             // 

--- a/Test/frmTest.cs
+++ b/Test/frmTest.cs
@@ -1,80 +1,113 @@
-﻿using System;
+using System;
+using System.Collections;
 using System.Windows.Forms;
 using Hitbtc;
 
 namespace Test
 {
+    /// <summary>Small interactive client for exercising the HitBTC API v3 wrapper.</summary>
     public partial class frmTest : Form
     {
+        private const string DefaultSymbol = "BTCUSDT";
+
         public frmTest()
         {
             InitializeComponent();
         }
 
-        private const string ApiKey = "<APIKEY>";
-        private const string SecretKey = "<SecretKey>";
-
         private async void btnPublicTest_Click(object sender, EventArgs e)
         {
-            var hitBtcRestApi = new HitBtcRestApi();
-            //var response = await hitBtcRestApi.PublicData.GetSymbol();
-            //var response = await hitBtcRestApi.PublicData.GetSymbol("BTCUSD");
-            //var response = await hitBtcRestApi.PublicData.GetCurrency();
-            //var response = await hitBtcRestApi.PublicData.GetCurrency("btc");
-            //var response = await hitBtcRestApi.PublicData.GetTicker();
-            //var response = await hitBtcRestApi.PublicData.GetTicker("BTCUSD");
-            //var response = await hitBtcRestApi.PublicData.GetOrderbook("BTCUSD", 10);
-            //gridviewReponse.DataSource = response.ask;
-            var response = await hitBtcRestApi.PublicData.GetCandles("BTCUSD");
-
-            gridviewReponse.DataSource = response;
+            await Run(async () => Bind(await new HitBtcRestApi().PublicData.GetTicker(DefaultSymbol)));
         }
 
         private async void btnTradingTest_Click(object sender, EventArgs e)
         {
-            var hitBtcRestApi = new HitBtcRestApi();
-            if (!hitBtcRestApi.IsAuthorized)
-                hitBtcRestApi.Authorize(ApiKey, SecretKey);
+            await Run(async () =>
+            {
+                var api = AuthorizedRestClient();
+                Bind(await api.Trading.GetOrders(DefaultSymbol));
+            });
+        }
 
-            //var response = await hitBtcRestApi.Trading.GetBalance();
-            //var response = await hitBtcRestApi.Trading.GetFee("BTCUSD");
-            var response = await hitBtcRestApi.Trading.GetOrders("BTCUSD");
-            gridviewReponse.DataSource = response;
+        private async void btnTradingHistory_Click(object sender, EventArgs e)
+        {
+            await Run(async () =>
+            {
+                var api = AuthorizedRestClient();
+                Bind(await api.TradingHistory.GetTraders(DefaultSymbol, null, null, 0));
+            });
         }
 
         private async void btnAccount_Click(object sender, EventArgs e)
         {
-            var hitBtcRestApi = new HitBtcRestApi();
-            if (!hitBtcRestApi.IsAuthorized)
-                hitBtcRestApi.Authorize(ApiKey, SecretKey);
-
-            //var response = await hitBtcRestApi.Account.GetBalance();
-            var response = await hitBtcRestApi.Account.GetAddress("btc");
-            gridviewReponse.DataSource = response;
+            await Run(async () => Bind(await AuthorizedRestClient().Account.GetBalance()));
         }
 
         private async void btnMarketData_Click(object sender, EventArgs e)
         {
-            var hitBtcSocketApi = new HitBtcSocketApi();
-            //var response = await hitBtcSocketApi.MarketData.GetCurrency("ETH");
-            //var response = await hitBtcSocketApi.MarketData.GetCurrencies();
-            var response = await hitBtcSocketApi.MarketData.GetTrades("BTCUSD","From","till",1);
-            //rtbResponse.Text = response.Content;
-            //var response = await hitBtcSocketApi.MarketData.UnsubscribeCandles("BTCUSD");
-            gridviewReponse.DataSource = response;
+            await Run(async () =>
+            {
+                using (var api = new HitBtcSocketApi())
+                    Bind(await api.MarketData.SubscribeTicker(DefaultSymbol));
+            });
         }
 
         private async void btnSocketTrading_Click(object sender, EventArgs e)
         {
-            var hitBtcSocketApi = new HitBtcSocketApi();
+            await Run(async () =>
+            {
+                using (var api = AuthorizedSocketClient())
+                    Bind(await api.Trading.GetTradingBalance());
+            });
+        }
 
-            if (!hitBtcSocketApi.IsAuthorized)
-                hitBtcSocketApi.Authorize(ApiKey, SecretKey);
+        private static HitBtcRestApi AuthorizedRestClient()
+        {
+            var api = new HitBtcRestApi();
+            api.Authorize(ApiKey(), SecretKey());
+            return api;
+        }
 
-            //var response = await hitBtcSocketApi.Trading.SubscribeReports();
-            var response = await hitBtcSocketApi.Trading.GetTradingBalance();
+        private static HitBtcSocketApi AuthorizedSocketClient()
+        {
+            var api = new HitBtcSocketApi();
+            api.Authorize(ApiKey(), SecretKey());
+            return api;
+        }
 
-            gridviewReponse.DataSource = response;
+        private static string ApiKey()
+        {
+            return RequiredEnvironmentVariable("HITBTC_API_KEY");
+        }
+
+        private static string SecretKey()
+        {
+            return RequiredEnvironmentVariable("HITBTC_SECRET_KEY");
+        }
+
+        private static string RequiredEnvironmentVariable(string name)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrWhiteSpace(value))
+                throw new InvalidOperationException("Set the " + name + " environment variable first.");
+            return value;
+        }
+
+        private void Bind(object response)
+        {
+            gridviewReponse.DataSource = response is IList ? response : new[] { response };
+        }
+
+        private static async System.Threading.Tasks.Task Run(Func<System.Threading.Tasks.Task> action)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show(exception.Message, "HitBTC API v3", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
     }
 }

--- a/Test/frmTest.cs
+++ b/Test/frmTest.cs
@@ -1,113 +1,344 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using Hitbtc;
+using Hitbtc.HitBtcModel;
 
 namespace Test
 {
-    /// <summary>Small interactive client for exercising the HitBTC API v3 wrapper.</summary>
+    /// <summary>Interactive, read-only verification console for HitBTC.Net API v3.</summary>
     public partial class frmTest : Form
     {
-        private const string DefaultSymbol = "BTCUSDT";
+        private const string ApiKeyVariable = "HITBTC_API_KEY";
+        private const string SecretKeyVariable = "HITBTC_SECRET_KEY";
 
         public frmTest()
         {
             InitializeComponent();
         }
 
-        private async void btnPublicTest_Click(object sender, EventArgs e)
+        private void frmTest_Load(object sender, EventArgs e)
         {
-            await Run(async () => Bind(await new HitBtcRestApi().PublicData.GetTicker(DefaultSymbol)));
+            LoadCredentialsFromEnvironment(false);
+            WriteLog(LogLevel.Info, "Console initialized. Public operations are ready.");
+            WriteLog(LogLevel.Info, "All available actions are read-only; no order, transfer, or withdrawal is submitted.");
+            if (HasCredentials)
+                WriteLog(LogLevel.Success, "Credentials were loaded from environment variables.");
+            else
+                WriteLog(LogLevel.Info, "Private operations require API key and secret fields.");
         }
 
-        private async void btnTradingTest_Click(object sender, EventArgs e)
+        private async void btnTicker_Click(object sender, EventArgs e)
         {
-            await Run(async () =>
+            await RunOperation("Get ticker", (Button)sender,
+                async () => await new HitBtcRestApi().PublicData.GetTicker(Symbol));
+        }
+
+        private async void btnSymbols_Click(object sender, EventArgs e)
+        {
+            await RunOperation("Get symbols", (Button)sender,
+                async () => await new HitBtcRestApi().PublicData.GetSymbol());
+        }
+
+        private async void btnCurrencies_Click(object sender, EventArgs e)
+        {
+            await RunOperation("Get currencies", (Button)sender,
+                async () => await new HitBtcRestApi().PublicData.GetCurrency());
+        }
+
+        private async void btnOrderBook_Click(object sender, EventArgs e)
+        {
+            await RunOperation("Get order book", (Button)sender, async () =>
             {
-                var api = AuthorizedRestClient();
-                Bind(await api.Trading.GetOrders(DefaultSymbol));
+                var orderbook = await new HitBtcRestApi().PublicData.GetOrderbook(Symbol, 25);
+                return ToOrderBookRows(orderbook);
             });
+        }
+
+        private async void btnCandles_Click(object sender, EventArgs e)
+        {
+            await RunOperation("Get M30 candles", (Button)sender,
+                async () => await new HitBtcRestApi().PublicData.GetCandles(Symbol, PublicEnum.EnPeriod.M30));
+        }
+
+        private async void btnSpotBalance_Click(object sender, EventArgs e)
+        {
+            await RunOperation("Get spot balance", (Button)sender,
+                async () => await CreateAuthorizedRestClient().Trading.GetBalance());
+        }
+
+        private async void btnActiveOrders_Click(object sender, EventArgs e)
+        {
+            await RunOperation("Get active orders", (Button)sender,
+                async () => await CreateAuthorizedRestClient().Trading.GetOrders(Symbol));
         }
 
         private async void btnTradingHistory_Click(object sender, EventArgs e)
         {
-            await Run(async () =>
-            {
-                var api = AuthorizedRestClient();
-                Bind(await api.TradingHistory.GetTraders(DefaultSymbol, null, null, 0));
-            });
+            await RunOperation("Get trade history", (Button)sender,
+                async () => await CreateAuthorizedRestClient().TradingHistory
+                    .GetTraders(Symbol, null, null, 0, 100));
         }
 
-        private async void btnAccount_Click(object sender, EventArgs e)
+        private async void btnWalletBalance_Click(object sender, EventArgs e)
         {
-            await Run(async () => Bind(await AuthorizedRestClient().Account.GetBalance()));
+            await RunOperation("Get wallet balance", (Button)sender,
+                async () => await CreateAuthorizedRestClient().Account.GetBalance());
         }
 
-        private async void btnMarketData_Click(object sender, EventArgs e)
+        private async void btnSubscribeTicker_Click(object sender, EventArgs e)
         {
-            await Run(async () =>
+            await RunOperation("Subscribe ticker WebSocket", (Button)sender, async () =>
             {
                 using (var api = new HitBtcSocketApi())
-                    Bind(await api.MarketData.SubscribeTicker(DefaultSymbol));
+                {
+                    var acknowledgement = await api.MarketData.SubscribeTicker(Symbol);
+                    WriteLog(LogLevel.Info, "Subscription acknowledgement received; this console does not keep a streaming listener open.");
+                    return acknowledgement;
+                }
             });
         }
 
-        private async void btnSocketTrading_Click(object sender, EventArgs e)
+        private async void btnSocketBalance_Click(object sender, EventArgs e)
         {
-            await Run(async () =>
+            await RunOperation("Get WebSocket trading balance", (Button)sender, async () =>
             {
-                using (var api = AuthorizedSocketClient())
-                    Bind(await api.Trading.GetTradingBalance());
+                using (var api = CreateAuthorizedSocketClient())
+                {
+                    var response = await api.Trading.GetTradingBalance();
+                    return response.Result;
+                }
             });
         }
 
-        private static HitBtcRestApi AuthorizedRestClient()
+        private async Task RunOperation(string operationName, Button source,
+            Func<Task<object>> operation)
         {
-            var api = new HitBtcRestApi();
-            api.Authorize(ApiKey(), SecretKey());
-            return api;
-        }
+            var timer = Stopwatch.StartNew();
+            SetBusy(true, operationName + "...");
 
-        private static HitBtcSocketApi AuthorizedSocketClient()
-        {
-            var api = new HitBtcSocketApi();
-            api.Authorize(ApiKey(), SecretKey());
-            return api;
-        }
-
-        private static string ApiKey()
-        {
-            return RequiredEnvironmentVariable("HITBTC_API_KEY");
-        }
-
-        private static string SecretKey()
-        {
-            return RequiredEnvironmentVariable("HITBTC_SECRET_KEY");
-        }
-
-        private static string RequiredEnvironmentVariable(string name)
-        {
-            var value = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrWhiteSpace(value))
-                throw new InvalidOperationException("Set the " + name + " environment variable first.");
-            return value;
-        }
-
-        private void Bind(object response)
-        {
-            gridviewReponse.DataSource = response is IList ? response : new[] { response };
-        }
-
-        private static async System.Threading.Tasks.Task Run(Func<System.Threading.Tasks.Task> action)
-        {
             try
             {
-                await action();
+                WriteLog(LogLevel.Request, operationName + " started" + OperationContext(operationName) + ".");
+                var result = await operation();
+                var count = BindResult(result);
+                timer.Stop();
+                WriteLog(LogLevel.Success, string.Format("{0} completed in {1:N0} ms; {2} row(s) displayed.",
+                    operationName, timer.Elapsed.TotalMilliseconds, count));
+                lblStatus.Text = operationName + " completed";
             }
             catch (Exception exception)
             {
-                MessageBox.Show(exception.Message, "HitBTC API v3", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                timer.Stop();
+                gridResults.DataSource = null;
+                lblResultCount.Text = "0 rows";
+                WriteLog(LogLevel.Error, FormatException(operationName, exception, timer.Elapsed));
+                lblStatus.Text = operationName + " failed";
             }
+            finally
+            {
+                SetBusy(false, lblStatus.Text);
+                source.Focus();
+            }
+        }
+
+        private int BindResult(object result)
+        {
+            gridResults.DataSource = null;
+            if (result == null)
+            {
+                lblResultCount.Text = "0 rows";
+                return 0;
+            }
+
+            var list = result as IList;
+            if (list != null)
+            {
+                gridResults.DataSource = list;
+                lblResultCount.Text = list.Count + " rows";
+                return list.Count;
+            }
+
+            gridResults.DataSource = new[] { result };
+            lblResultCount.Text = "1 row";
+            return 1;
+        }
+
+        private static List<OrderBookRow> ToOrderBookRows(Orderbook orderbook)
+        {
+            var rows = new List<OrderBookRow>();
+            if (orderbook == null) return rows;
+            if (orderbook.Ask != null)
+                rows.AddRange(orderbook.Ask.Select((level, index) =>
+                    new OrderBookRow(index + 1, "Ask", level.Price, level.Size, orderbook.Timestamp)));
+            if (orderbook.Bid != null)
+                rows.AddRange(orderbook.Bid.Select((level, index) =>
+                    new OrderBookRow(index + 1, "Bid", level.Price, level.Size, orderbook.Timestamp)));
+            return rows;
+        }
+
+        private HitBtcRestApi CreateAuthorizedRestClient()
+        {
+            EnsureCredentials();
+            var api = new HitBtcRestApi();
+            api.Authorize(txtApiKey.Text.Trim(), txtSecret.Text);
+            return api;
+        }
+
+        private HitBtcSocketApi CreateAuthorizedSocketClient()
+        {
+            EnsureCredentials();
+            var api = new HitBtcSocketApi();
+            api.Authorize(txtApiKey.Text.Trim(), txtSecret.Text);
+            return api;
+        }
+
+        private void EnsureCredentials()
+        {
+            if (!HasCredentials)
+                throw new InvalidOperationException("Enter API key and secret, or load HITBTC_API_KEY and HITBTC_SECRET_KEY from the environment.");
+        }
+
+        private bool HasCredentials =>
+            !string.IsNullOrWhiteSpace(txtApiKey.Text) && !string.IsNullOrWhiteSpace(txtSecret.Text);
+
+        private string Symbol
+        {
+            get
+            {
+                var symbol = txtSymbol.Text.Trim().ToUpperInvariant();
+                if (string.IsNullOrWhiteSpace(symbol))
+                    throw new InvalidOperationException("Enter a trading symbol such as BTCUSDT.");
+                return symbol;
+            }
+        }
+
+        private string OperationContext(string operationName)
+        {
+            return operationName.IndexOf("balance", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   operationName.IndexOf("currencies", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   operationName.IndexOf("symbols", StringComparison.OrdinalIgnoreCase) >= 0
+                ? string.Empty
+                : " for " + Symbol;
+        }
+
+        private void btnLoadEnvironment_Click(object sender, EventArgs e)
+        {
+            LoadCredentialsFromEnvironment(true);
+        }
+
+        private void LoadCredentialsFromEnvironment(bool reportResult)
+        {
+            txtApiKey.Text = Environment.GetEnvironmentVariable(ApiKeyVariable) ?? string.Empty;
+            txtSecret.Text = Environment.GetEnvironmentVariable(SecretKeyVariable) ?? string.Empty;
+            if (!reportResult) return;
+
+            WriteLog(HasCredentials ? LogLevel.Success : LogLevel.Error,
+                HasCredentials
+                    ? "Credentials loaded from environment variables."
+                    : "Environment credentials were not found or were incomplete.");
+        }
+
+        private void chkShowSecret_CheckedChanged(object sender, EventArgs e)
+        {
+            txtApiKey.UseSystemPasswordChar = !chkShowSecret.Checked;
+            txtSecret.UseSystemPasswordChar = !chkShowSecret.Checked;
+            WriteLog(LogLevel.Info, chkShowSecret.Checked ? "Credential visibility enabled." : "Credential visibility disabled.");
+        }
+
+        private void btnClearLog_Click(object sender, EventArgs e)
+        {
+            txtLog.Clear();
+            WriteLog(LogLevel.Info, "Log cleared.");
+        }
+
+        private void SetBusy(bool busy, string status)
+        {
+            actionsPanel.Enabled = !busy;
+            settingsPanel.Enabled = !busy;
+            Cursor = busy ? Cursors.WaitCursor : Cursors.Default;
+            lblStatus.Text = status;
+        }
+
+        private void WriteLog(LogLevel level, string message)
+        {
+            var color = Color.FromArgb(209, 213, 219);
+            var label = "INFO";
+            switch (level)
+            {
+                case LogLevel.Request:
+                    color = Color.FromArgb(96, 165, 250);
+                    label = "SEND";
+                    break;
+                case LogLevel.Success:
+                    color = Color.FromArgb(74, 222, 128);
+                    label = " OK ";
+                    break;
+                case LogLevel.Error:
+                    color = Color.FromArgb(248, 113, 113);
+                    label = "ERROR";
+                    break;
+            }
+
+            txtLog.SelectionStart = txtLog.TextLength;
+            txtLog.SelectionColor = Color.FromArgb(156, 163, 175);
+            txtLog.AppendText(DateTime.Now.ToString("HH:mm:ss.fff") + "  ");
+            txtLog.SelectionColor = color;
+            txtLog.AppendText("[" + label + "] ");
+            txtLog.SelectionColor = Color.FromArgb(229, 231, 235);
+            txtLog.AppendText(message + Environment.NewLine);
+            txtLog.SelectionStart = txtLog.TextLength;
+            txtLog.ScrollToCaret();
+        }
+
+        private static string FormatException(string operation, Exception exception,
+            TimeSpan elapsed)
+        {
+            var restError = exception as HitBtcApiException;
+            if (restError != null)
+                return string.Format("{0} failed after {1:N0} ms: {2} (HTTP {3}, API code {4}).",
+                    operation, elapsed.TotalMilliseconds, restError.Message,
+                    (int)restError.StatusCode, restError.ApiErrorCode ?? "n/a");
+
+            var socketError = exception as HitBtcWebSocketException;
+            if (socketError != null)
+                return string.Format("{0} failed after {1:N0} ms: {2} (API code {3}).",
+                    operation, elapsed.TotalMilliseconds, socketError.Message,
+                    socketError.ApiErrorCode ?? "n/a");
+
+            return string.Format("{0} failed after {1:N0} ms: {2}: {3}", operation,
+                elapsed.TotalMilliseconds, exception.GetType().Name, exception.Message);
+        }
+
+        private enum LogLevel
+        {
+            Info,
+            Request,
+            Success,
+            Error
+        }
+
+        private sealed class OrderBookRow
+        {
+            public OrderBookRow(int level, string side, string price, string size, string timestamp)
+            {
+                Level = level;
+                Side = side;
+                Price = price;
+                Size = size;
+                Timestamp = timestamp;
+            }
+
+            public int Level { get; }
+            public string Side { get; }
+            public string Price { get; }
+            public string Size { get; }
+            public string Timestamp { get; }
         }
     }
 }

--- a/Wiki/Home.md
+++ b/Wiki/Home.md
@@ -1,0 +1,204 @@
+# HitBTC.Net Wiki
+
+[English](#english) · [فارسی](#فارسی)
+
+## English
+
+### Overview
+
+HitBTC.Net is an unofficial C# client for HitBTC API v3. It targets .NET Framework 4.8 and supports public market data, spot trading, wallet operations, trading history, and public/authenticated WebSocket commands.
+
+### Project layout
+
+| Project | Description |
+| --- | --- |
+| `HitBtc` | Main class library and API models |
+| `HitBtc.Tests` | Deterministic xUnit test suite |
+| `Test` | Interactive WinForms demo |
+
+### Build and test
+
+```powershell
+nuget restore Hitbtc.sln
+dotnet build Hitbtc.sln --configuration Release --no-restore
+dotnet test HitBtc.Tests/HitBtc.Tests.csproj --configuration Release --no-build --no-restore
+```
+
+The primary output is `HitBtc/bin/Release/Hitbtc.dll`.
+
+### REST quick start
+
+```csharp
+using Hitbtc;
+
+var api = new HitBtcRestApi();
+var ticker = await api.PublicData.GetTicker("BTCUSDT");
+```
+
+Private endpoints require authorization:
+
+```csharp
+api.Authorize(apiKey, secretKey);
+var balances = await api.Trading.GetBalance();
+```
+
+Never hard-code credentials. Read them from environment variables or a secure secret store.
+
+### WebSocket quick start
+
+```csharp
+using (var socket = new HitBtcSocketApi())
+{
+    await socket.MarketData.SubscribeTicker("BTCUSDT");
+}
+```
+
+API v3 uses separate public and trading WebSocket endpoints. Currency, symbol, and historical-trade lookups must use the REST client.
+
+### API v3 migration
+
+- REST resources now use `/api/3/public`, `/api/3/spot`, and `/api/3/wallet`.
+- JSON fields and parameters use snake_case.
+- Public collections can be dictionaries keyed by symbol or currency.
+- Order-book entries are `[price, size]` arrays.
+- WebSocket subscriptions use channels such as `ticker/1s`.
+- Wallet transfers specify `source` and `destination` accounts.
+
+### Demo credentials
+
+```powershell
+$env:HITBTC_API_KEY = "your-api-key"
+$env:HITBTC_SECRET_KEY = "your-secret-key"
+dotnet run --project Test/Test.csproj
+```
+
+### Releases
+
+Merge changes through a pull request to the protected `master` branch. After CI succeeds, create and push a semantic version tag:
+
+```powershell
+git tag -a v1.1.0 -m "Release v1.1.0"
+git push origin v1.1.0
+```
+
+The GitHub Actions workflow builds and tests the tagged commit, creates a ZIP package, and attaches it to a GitHub Release.
+
+### License
+
+HitBTC.Net is distributed under the [MIT License](https://github.com/iarash84/hitbtc.net/blob/master/LICENSE). It can be used,
+modified, and redistributed as long as the copyright and permission notices are
+retained. The software is provided without warranty.
+
+---
+
+<div dir="rtl" align="right">
+
+## فارسی
+
+### معرفی
+
+HitBTC.Net یک کلاینت غیررسمی C# برای API نسخهٔ ۳ صرافی HitBTC است. پروژه بر پایهٔ .NET Framework 4.8 ساخته شده و داده‌های عمومی بازار، معاملات اسپات، کیف پول، تاریخچهٔ معاملات و WebSocket عمومی و خصوصی را پوشش می‌دهد.
+
+### ساختار پروژه
+
+| پروژه | توضیح |
+| --- | --- |
+| `HitBtc` | کتابخانهٔ اصلی و مدل‌های API |
+| `HitBtc.Tests` | تست‌های قطعی xUnit |
+| `Test` | برنامهٔ نمایشی WinForms |
+
+### بیلد و تست
+
+</div>
+
+```powershell
+nuget restore Hitbtc.sln
+dotnet build Hitbtc.sln --configuration Release --no-restore
+dotnet test HitBtc.Tests/HitBtc.Tests.csproj --configuration Release --no-build --no-restore
+```
+
+<div dir="rtl" align="right">
+
+خروجی اصلی در مسیر `HitBtc/bin/Release/Hitbtc.dll` ساخته می‌شود.
+
+### شروع سریع REST
+
+</div>
+
+```csharp
+using Hitbtc;
+
+var api = new HitBtcRestApi();
+var ticker = await api.PublicData.GetTicker("BTCUSDT");
+
+api.Authorize(apiKey, secretKey);
+var balances = await api.Trading.GetBalance();
+```
+
+<div dir="rtl" align="right">
+
+کلیدهای API را داخل کد قرار ندهید. آن‌ها را از متغیر محیطی یا یک مخزن امن اسرار دریافت کنید.
+
+### شروع سریع WebSocket
+
+</div>
+
+```csharp
+using (var socket = new HitBtcSocketApi())
+{
+    await socket.MarketData.SubscribeTicker("BTCUSDT");
+}
+```
+
+<div dir="rtl" align="right">
+
+نسخهٔ ۳ برای داده‌های عمومی و عملیات معاملاتی از endpointهای WebSocket جداگانه استفاده می‌کند. دریافت ارزها، نمادها و تاریخچهٔ معامله باید از طریق REST انجام شود.
+
+### مهاجرت به API نسخهٔ ۳
+
+- مسیرها به گروه‌های `/api/3/public`، `/api/3/spot` و `/api/3/wallet` منتقل شده‌اند.
+- فیلدها و پارامترهای JSON از الگوی snake_case استفاده می‌کنند.
+- مجموعه‌های عمومی ممکن است با نام نماد یا ارز کلیدگذاری شده باشند.
+- هر ردیف order book به شکل آرایهٔ `[price, size]` برمی‌گردد.
+- اشتراک WebSocket با کانال‌هایی مانند `ticker/1s` انجام می‌شود.
+- انتقال کیف پول دارای حساب‌های `source` و `destination` است.
+
+### اعتبارنامه‌های برنامهٔ نمونه
+
+</div>
+
+```powershell
+$env:HITBTC_API_KEY = "your-api-key"
+$env:HITBTC_SECRET_KEY = "your-secret-key"
+dotnet run --project Test/Test.csproj
+```
+
+<div dir="rtl" align="right">
+
+### انتشار نسخهٔ جدید
+
+تغییرات را با Pull Request در شاخهٔ محافظت‌شدهٔ `master` ادغام کنید. پس از موفقیت CI یک تگ نسخهٔ معنایی بسازید و push کنید:
+
+</div>
+
+```powershell
+git tag -a v1.1.0 -m "Release v1.1.0"
+git push origin v1.1.0
+```
+
+<div dir="rtl" align="right">
+
+GitHub Actions کد همان تگ را بیلد و تست می‌کند، فایل ZIP می‌سازد و آن را به GitHub Release متصل می‌کند.
+
+### امنیت و مشارکت
+
+- کلید یا رمز API را commit نکنید.
+- تست‌های معمول نباید به سرویس زنده وابسته باشند.
+- برای رفع هر باگ تست بازگشتی اضافه کنید.
+- قبل از ارسال Pull Request بیلد Release و تست‌ها را اجرا کنید.
+
+### مجوز
+
+HitBTC.Net تحت [مجوز MIT](https://github.com/iarash84/hitbtc.net/blob/master/LICENSE) منتشر می‌شود. استفاده، تغییر و بازتوزیع آن با حفظ اعلان حق نشر و متن مجوز مجاز است. نرم‌افزار بدون ضمانت ارائه می‌شود.
+
+</div>

--- a/Wiki/Home.md
+++ b/Wiki/Home.md
@@ -43,6 +43,8 @@ var balances = await api.Trading.GetBalance();
 ```
 
 Never hard-code credentials. Read them from environment variables or a secure secret store.
+REST failures throw `HitBtcApiException`; HTTP status and exchange error code are
+available when supplied by the server.
 
 ### WebSocket quick start
 
@@ -54,6 +56,9 @@ using (var socket = new HitBtcSocketApi())
 ```
 
 API v3 uses separate public and trading WebSocket endpoints. Currency, symbol, and historical-trade lookups must use the REST client.
+Malformed responses, exchange errors, and mismatched response IDs throw
+`HitBtcWebSocketException`. Subscription methods currently return only the
+acknowledgement and do not expose a continuous high-level notification stream.
 
 ### API v3 migration
 
@@ -139,6 +144,8 @@ var balances = await api.Trading.GetBalance();
 
 کلیدهای API را داخل کد قرار ندهید. آن‌ها را از متغیر محیطی یا یک مخزن امن اسرار دریافت کنید.
 
+خطاهای REST با `HitBtcApiException` گزارش می‌شوند و در صورت موجود بودن، وضعیت HTTP و کد خطای صرافی قابل دسترسی است.
+
 ### شروع سریع WebSocket
 
 </div>
@@ -153,6 +160,8 @@ using (var socket = new HitBtcSocketApi())
 <div dir="rtl" align="right">
 
 نسخهٔ ۳ برای داده‌های عمومی و عملیات معاملاتی از endpointهای WebSocket جداگانه استفاده می‌کند. دریافت ارزها، نمادها و تاریخچهٔ معامله باید از طریق REST انجام شود.
+
+پاسخ خراب، خطای صرافی یا شناسهٔ پاسخ نامنطبق با `HitBtcWebSocketException` گزارش می‌شود. متدهای اشتراک فعلی فقط acknowledgement را برمی‌گردانند و جریان سطح‌بالای notification هنوز پیاده‌سازی نشده است.
 
 ### مهاجرت به API نسخهٔ ۳
 

--- a/Wiki/Home.md
+++ b/Wiki/Home.md
@@ -77,6 +77,10 @@ $env:HITBTC_SECRET_KEY = "your-secret-key"
 dotnet run --project Test/Test.csproj
 ```
 
+The demo is a read-only verification console with grouped REST/WebSocket actions,
+masked credentials, a result grid, operation status, and a timestamped activity
+log. It never submits orders, transfers, or withdrawals.
+
 ### Releases
 
 Merge changes through a pull request to the protected `master` branch. After CI succeeds, create and push a semantic version tag:
@@ -181,6 +185,12 @@ $env:HITBTC_API_KEY = "your-api-key"
 $env:HITBTC_SECRET_KEY = "your-secret-key"
 dotnet run --project Test/Test.csproj
 ```
+
+<div dir="rtl" align="right">
+
+برنامهٔ نمونه یک کنسول تست فقط‌خواندنی با عملیات دسته‌بندی‌شدهٔ REST و WebSocket، اعتبارنامهٔ مخفی، جدول نتایج، وضعیت عملیات و لاگ زمان‌دار است. این برنامه هیچ سفارش، انتقال یا برداشتی ثبت نمی‌کند.
+
+</div>
 
 <div dir="rtl" align="right">
 

--- a/Wiki/_Sidebar.md
+++ b/Wiki/_Sidebar.md
@@ -1,0 +1,11 @@
+## HitBTC.Net
+
+- [Home / خانه](Home)
+- [Repository README](../README.md)
+- [MIT License](https://github.com/iarash84/hitbtc.net/blob/master/LICENSE)
+
+<div dir="rtl" align="right">
+
+مستندات این Wiki به دو زبان انگلیسی و فارسی ارائه شده است.
+
+</div>


### PR DESCRIPTION
## Summary

This pull request modernizes the HitBTC.Net client and migrates the project to HitBTC API v3. It also improves reliability, automated testing, documentation, licensing, and the WinForms manual test console.

## Key changes

- Migrated REST and WebSocket endpoints from API v2 to API v3
- Updated models and parameters to match the new `snake_case` contracts
- Added support for the new symbol, currency, ticker, order-book, wallet, and spot structures
- Improved REST and WebSocket error handling with typed exceptions
- Added validation for malformed JSON, API errors, oversized messages, and mismatched response IDs
- Prevented external modification of authentication state
- Added a testable REST transport abstraction
- Expanded automated coverage for REST, WebSocket, serialization, authentication, and edge cases
- Redesigned the WinForms test console with:
  - Public REST, private REST, and WebSocket operation groups
  - Editable symbol and masked credential inputs
  - Structured result grid
  - Timestamped activity and error logs
  - Read-only operations to prevent accidental trading or withdrawals
- Added bilingual English/Persian README and Wiki documentation
- Added the MIT license

## API v3 migration notes

API v3 introduces new REST resource groups, separate public and trading WebSocket endpoints, `snake_case` fields, dictionary-based public collections, and compact order-book levels.

Most existing C# method names were preserved where practical. Legacy misspelled withdrawal methods remain available as obsolete compatibility members, with correctly named alternatives added.

## Verification

- Release build completed without compilation errors
- Automated tests: **60 passed, 0 failed**
- Public API v3 endpoints for ticker, symbol, order book, and candles were verified against the live read-only service
- Automated tests remain deterministic and do not require real credentials or live exchange connectivity

## Security

- API credentials are not hard-coded or logged
- The test console loads credentials from environment variables or masked inputs
- Private endpoint tests require explicitly supplied credentials
- The test console does not submit orders, transfers, or withdrawals

## Remaining limitations

- WebSocket subscriptions currently validate the acknowledgement but do not expose a continuous high-level notification stream
- Automatic WebSocket reconnection and backoff are not yet implemented
- Private endpoints were not exercised against a funded live account to avoid unintended financial operations